### PR TITLE
MAUI-3102 Fixed the Autocomplete ComboBox UG syntax error in getting started page

### DIFF
--- a/MAUI/Autocomplete/Getting-Started.md
+++ b/MAUI/Autocomplete/Getting-Started.md
@@ -47,7 +47,9 @@ namespace AutocompleteSample
             return builder.Build();
         }      
     }
-}     
+}   
+
+{% endhighlight %}  
 
 ## Create a Simple .NET MAUI Autocomplete
 

--- a/MAUI/ComboBox/Getting-Started.md
+++ b/MAUI/ComboBox/Getting-Started.md
@@ -47,7 +47,9 @@ namespace ComboBoxSample
             return builder.Build();
         }      
     }
-}     
+}    
+
+{% endhighlight %} 
 
 ## Create a Simple .NET MAUI ComboBox
 


### PR DESCRIPTION
### Bug Description ###

Liquid Exception thrown in Autocomplete and ComboBox Getting started page

### Root Cause ###

Didn't close the highlight tag


### Solution description ###

Closed the endhighlight tag.


### MR CheckList ###

- [ ] Does it follow the design [guidelines](https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/)? It is mandatory that, we should not move the changes without reading this. (NA)
- [ ] Did UI automation passed without errors? If it is customer issue, make sure it is included in the IR automation.
- [ ] Properly working in Xamarin.Forms [previewer](https://docs.microsoft.com/en-us/xamarin/xamarin-forms/xaml/xaml-previewer?tabs=vswin). (NA)
- [ ] Ensured in iOS, Android, UWP and macOS (if supported). (NA)
- [ ] Have you ensured the changes in Android API 19 and iOS 9? (NA)
- [ ] Did you record this case in the unit test or UI test? (NA)