### PR TITLE
MAUI-3166 : Removed the bracket in maps migration document..

### DIFF
--- a/MAUI/Maps/migration.md
+++ b/MAUI/Maps/migration.md
@@ -2481,7 +2481,7 @@ public MainPage()
 </tr>
 <tr>
    <td>
-      {{'[-]'| markdownify }}
+      {{'-'| markdownify }}
    </td>
    <td>
       {{'[StrokeDashArray](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Maps.MapPolyline.html#Syncfusion_Maui_Maps_MapPolyline_StrokeDashArray)'| markdownify }}


### PR DESCRIPTION
Hi @vigneshrameshsync ,
I removed unwanted bracket for the MAUI Maps Sublayer UG. Could you please review it?

Regards,
Shalini Ashokan.