### PR TITLE
MAUI-3213 : Removed the note under color mapping section in the MAUI maps migration document.

### DIFF
--- a/MAUI/Maps/migration.md
+++ b/MAUI/Maps/migration.md
@@ -2120,8 +2120,6 @@ public MainPage()
 </tr>
 </table>
 
-N> All the (*) marked APIs are renamed from Xamarin SfMaps to maintain the consistency of API naming in the .NET MAUI SfMaps.
-
 The following code example explains how to customize the shape color in the Xamarin SfMaps and .Net MAUI SfMaps.
 
 <table>


### PR DESCRIPTION
Hi @vigneshrameshsync ,

I have removed the note under the color mapping section in the MAUI map migration document.

Regards,
Balachandar. 