### PR TITLE
ColumnSizer not aplicable for Maui

### DIFF
--- a/MAUI/DataGrid/Getting-started.md
+++ b/MAUI/DataGrid/Getting-started.md
@@ -225,7 +225,7 @@ The columns can be manually defined by setting the `SfDataGrid.AutoGenerateColum
 {% tabs %}
 {% highlight xaml %}
 <syncfusion:SfDataGrid x:Name="dataGrid"
-            ColumnSizer="Star"
+            ColumnWidthMode="Fill"
             AutoGenerateColumnsMode="None"
             ItemsSource="{Binding OrderInfoCollection}">
 


### PR DESCRIPTION
Remove   ColumnSizer="Star"

Add  ColumnWidthMode="Fill"

Ref https://help.syncfusion.com/maui/datagrid/column-sizing