### PR TITLE
MAUI-2819 Error Correction in the Migration Documentation Page.

### DIFF
--- a/MAUI/Common/migration.md
+++ b/MAUI/Common/migration.md
@@ -222,7 +222,7 @@ Currently working on delivering brand-new .NET MAUI controls that can be used in
 			<a href="https://help.syncfusion.com/xamarin/pdf-viewer/getting-started">SfPdfViewer</a><br/>
 		</td>
 		<td rowspan="1" valign="top">
-		    <a href="">SfPdfViewer</a><br/>
+		    SfPdfViewer<br/>
 		</td>
 	</tr>
 	<tr>


### PR DESCRIPTION
* In Pdf Viewers there is no Migration document page so removed the link syntax.