### PR TITLE
MAUI-4213 Fixed the Syntax Error in the .NET MAUI Introduction and Migration Page.

### DIFF
--- a/MAUI/Common/migration.md
+++ b/MAUI/Common/migration.md
@@ -238,7 +238,7 @@ Currently working on delivering brand-new .NET MAUI controls that can be used in
 			<a href="https://help.syncfusion.com/xamarin/calendar/getting-started">SfCalendar</a><br/>
 		</td>
 		<td rowspan="1" valign="top">
-			<a href="https://help.syncfusion.com/maui/calendar/migration">SfCalendar<br/>
+			<a href="https://help.syncfusion.com/maui/calendar/migration">SfCalendar</a><br/>
 		</td>
 	</tr>
 	<tr>
@@ -246,7 +246,7 @@ Currently working on delivering brand-new .NET MAUI controls that can be used in
 			<a href="https://help.syncfusion.com/xamarin/dataform/getting-started">SfDataForm</a><br/>
 		</td>
 		<td rowspan="1" valign="top">
-			<a href="https://help.syncfusion.com/maui/dataform/migration">SfDataForm<br/>
+			<a href="https://help.syncfusion.com/maui/dataform/migration">SfDataForm</a><br/>
 		</td>
 	</tr>
 	<tr>

--- a/MAUI/Introduction/MAUI-cross-platform-UI.md
+++ b/MAUI/Introduction/MAUI-cross-platform-UI.md
@@ -224,7 +224,7 @@ You can find the platforms supported by each .NET MAUI control as below.
 	    <td rowspan="3" valign="top">
 			LAYOUT<br/>
 		</td>
-	    	<td>
+	    <td>
 			<a href="/maui/backdrop/overview ">Backdrop Page</a><br/>
 		</td>
 		<td>
@@ -238,6 +238,7 @@ You can find the platforms supported by each .NET MAUI control as below.
 		</td>
 		<td>
 		Yes<br/>
+		</td>
 	</tr>
 	<tr>
 		<td>
@@ -484,8 +485,7 @@ You can find the platforms supported by each .NET MAUI control as below.
 		<td>
 		Yes<br/>
 		</td>
-		</td>
-		</tr>
+	</tr>
 	<tr>
 		<td>
 			<a href="/maui/scheduler/overview">Scheduler</a><br/>


### PR DESCRIPTION
* Fixed the syntax error.