### PR TITLE
MAUI-4918-Create-UG-for-Error-Bar-and-waterfall-Series-in-MAUI__Modification

### DIFF
--- a/MAUI/Cartesian-Charts/Errorbar-Chart.md
+++ b/MAUI/Cartesian-Charts/Errorbar-Chart.md
@@ -503,9 +503,7 @@ You can define the LineStyle for the error bar lines using the [HorizontalLineSt
 
 ### Cap Line Style
 
-You can define the CapLineStyle for the error bar lines using the [HorizontalCapLineStyle]() and the[VerticalCapLineStyle]() properties as in the following code examples.
-
-#### Horizontal Cap Line Style
+You can define the CapLineStyle for the error bar lines using the [HorizontalCapLineStyle]() and the [VerticalCapLineStyle]() properties as in the following code examples.
 
 {% tabs %}
 

--- a/MAUI/Cartesian-Charts/Waterfall-Chart.md
+++ b/MAUI/Cartesian-Charts/Waterfall-Chart.md
@@ -78,7 +78,7 @@ documentation: ug
 
 ### Connector line customization
 
-The connector line can be customized by applying the[ConnectorLineStyle]() property of the series.
+The connector line can be customized by applying the [ConnectorLineStyle]() property of the series.
 The following code example illustrates how to apply style for connector line.
 
 {% tabs %}


### PR DESCRIPTION
### Description ###
 
User Guide for the Error Bar Series and Waterfall Series in MAUI Platform

### What problem it solves? ###
All about the Error bar Series feature and its types. And Initialising the error Bar Series was explained here.
All about the waterfall Series feature And Initialising the waterfall Series was explained here.
 
 
### Solution description ###
 
- I Created the UG Document in md Format named as ErrorBar.md
- I attached a folder contains the Chart_types Images for Error Bar Series
- I attached the images to the md file
- I Created the UG Document in md Format named as Waterfall.md
- I attached a folder contains the Chart_types Images for Waterfall Series
- I attached the images to the md file
- I added the Waterfall Series in the html List file


### Output Screenshot ###
 
<img width="370" alt="BasicRenderingErrorBar" src="https://user-images.githubusercontent.com/113962276/224912913-5e19b1f2-846f-4e2b-a966-b50cf03c9d64.png">
<img width="395" alt="BasicRendering" src="https://user-images.githubusercontent.com/113962276/224913251-4a368021-3a96-4e6c-b3f6-c506f19182e9.png">
<img width="391" alt="NegativePointsBrush" src="https://user-images.githubusercontent.com/113962276/224913280-64e84ea6-917b-475d-aadf-e38d94b34c38.png">
<img width="383" alt="SummaryBindingPath" src="https://user-images.githubusercontent.com/113962276/224913315-3fb3048d-95e6-4674-8450-6eb35a5169e2.png">







