### PR TITLE
829272 - [others] UG documentation for caption and group summary rows.

### DIFF
--- a/MAUI/DataGrid/Summaries.md
+++ b/MAUI/DataGrid/Summaries.md
@@ -11,6 +11,8 @@ documentation: UG
 
 The data grid supports to display the concise information about the bound data objects using summaries. The control provides the following summary types:
 
+* **Caption Summary** - Used to display the summary information in the caption of the group.
+* **Group Summary** - Used to display summary information of data objects in each group.
 * **Table Summary** - Used to display the summary information at top and/or bottom in SfDataGrid.
 
 
@@ -22,6 +24,609 @@ Derive additional information from the data like sum, average, maximum, minimum,
 
 N> The Summary does not refresh with data. To update the summary for the newly added row, or for the modified summary column, set the [SfDataGrid.View.LiveDataUpdateMode](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Data.LiveDataUpdateMode.html) to `LiveDataUpdateMode.AllowDataShaping` or `LiveDataUpdateMode.AllowSummaryUpdate`.
 
+## Caption summaries
+
+The data grid provides built-in support for caption summaries. The caption summary value calculated based on the records in a group. The summary information will be displayed in the caption of group.
+
+### Formatting built-in caption summary
+
+By default, the caption summary rows in the data grid are displayed using the [SfDataGrid.GroupCaptionTextFormat]() property.
+
+Default group caption format is `{ColumnName}: {Key} - {ItemsCount} Items`.
+
+* **ColumnName**: Displays the name of the currently grouped column.
+* **Key**: Displays the key value of the group.
+* **ItemsCount**: Displays the number of items in a group.
+
+![DataGrid with formatting in caption summary row](Images\caption-summary\maui-datagrid-default.png)
+
+You can customize the group caption text format by setting the `SfDataGrid.GroupCaptionTextFormat` property. The code example below illustrates how to customize the group caption text in the data grid:
+
+{% tabs %}
+{% highlight xaml%}
+    <sfGrid:SfDataGrid x:Name="dataGrid"
+                       AutoGenerateColumns="True"
+                       ColumnSizer="Star"
+                       GroupCaptionTextFormat="{}{ColumnName}: {Key}">
+{% endhighlight %}
+
+{% highlight c#%}
+// Customized group caption text
+dataGrid.GroupCaptionTextFormat = "{ColumnName} : {Key}";
+{% endhighlight %}
+{% endtabs %}
+
+The following screenshot shows the outcome of the previous code:
+
+![DataGrid with formatting in caption summary row](Images\caption-summary\maui-datagrid-formatting-show-summary-in-row.png)
+
+
+### Displaying summary for a row
+
+Display summary information in a row by setting the [DataGridSummaryRow.ShowSummaryInRow]() property to `true` and define summary columns. You have to define the [DataGridSummaryRow.Title]() based on the [DataGridSummaryColumn.Name]() property in order to format the values of the summary columns in the row.
+
+{% tabs %}
+{% highlight xaml%}
+    <sfGrid:SfDataGrid.CaptionSummaryRow>
+        <sfGrid:DataGridSummaryRow Title="Total Salary :{TotalSalary} for {ProductCount} members"
+                                   ShowSummaryInRow="True">
+            <sfGrid:DataGridSummaryRow.SummaryColumns>
+                <sfGrid:DataGridSummaryColumn Name="TotalSalary"
+                                              Format="{}{Sum:C0}"
+                                              MappingName="Salary"
+                                              SummaryType="Int32Aggregate" />
+                <sfGrid:DataGridSummaryColumn Name="ProductCount"
+                                              Format="{}{Count}"
+                                              MappingName="Salary"
+                                              SummaryType="CountAggregate" />
+            </sfGrid:DataGridSummaryRow.SummaryColumns>
+        </sfGrid:DataGridSummaryRow>
+    </sfGrid:SfDataGrid.CaptionSummaryRow>
+{% endhighlight %}
+
+{% highlight c#%}
+DataGridSummaryRow summaryRow = new DataGridSummaryRow();
+summaryRow.Title = "Total Salary:{TotalSalary} for {ProductCount} members";
+summaryRow.ShowSummaryInRow = true;
+summaryRow.SummaryColumns.Add(new DataGridSummaryColumn()
+{
+    Name = "TotalSalary",
+    MappingName = "Salary",
+    Format = "{Sum:c}",
+    SummaryType = SummaryType.DoubleAggregate
+});
+summaryRow.SummaryColumns.Add(new DataGridSummaryColumn()
+{
+    Name = "ProductCount",
+    MappingName = "Salary",
+    Format = "{Count}",
+    SummaryType = SummaryType.CountAggregate
+});
+sfGrid.CaptionSummaryRow= summaryRow;
+{% endhighlight %}
+{% endtabs %}
+
+The following screenshot shows the outcome for both values of `ShowSummaryInRow` to `true`:
+
+![DataGrid with customized caption summary row](Images\caption-summary\maui-datagrid-show-summary-in-row.png)
+
+
+### Displaying summary for column
+
+To display summary information in a column, you need to set the `DataGridSummaryRow.ShowSummaryInRow` to `false` and define summary columns using the `SfDataGrid.DataGridSummaryColumn` object. The `DataGridSummaryColumn` object has several important properties:
+
+* [Name](): This property defines the name of the `DataGridSummaryColumn`, which is used to identify the column in the `DataGridSummaryRow` and provide a title for it.
+* [MappingName](): This property defines the corresponding column name used for the summary calculation.
+* [SummaryType]():  This property defines the `SummaryType` enum property, which determines the type of aggregate function used for the summary calculation. 
+
+The DataGrid control provides several predefined aggregates, such as CountAggregate, Int32Aggregate, and DoubleAggregate. When the summary type is set as Custom, you can define a CustomAggregate class object to calculate custom summaries.
+
+The [Format]() property defines a string property that formats the summary value and displays it. The Format property can have two parts separated by a colon (:). The first part denotes the aggregate function name, and the second part denotes the display format of the summary value.
+
+Please refer to the "Formatting Summary" section for more information on how to format the summary, and the "Aggregate Types" section to learn about the different summary types.
+
+In the following code snippet, a summary is defined for the `Salary` column:
+
+{% tabs %}
+{% highlight xaml%}
+    <sfGrid:SfDataGrid.CaptionSummaryRow>
+        <sfGrid:DataGridSummaryRow Name="CaptionSummary"
+                                   ShowSummaryInRow="False">
+            <sfGrid:DataGridSummaryRow.SummaryColumns>
+                <sfGrid:DataGridSummaryColumn Name="CaptionSummary"
+                                              Format="{}{Sum:C0}"
+                                              MappingName="Salary"
+                                              SummaryType="DoubleAggregate" />
+            </sfGrid:DataGridSummaryRow.SummaryColumns>
+        </sfGrid:DataGridSummaryRow>
+    </sfGrid:SfDataGrid.CaptionSummaryRow>
+{% endhighlight %}
+
+{% highlight c#%}
+DataGridSummaryRow summaryRow = new DataGridSummaryRow();
+summaryRow.ShowSummaryInRow = false;
+summaryRow.SummaryColumns.Add(new DataGridSummaryColumn()
+{
+    Name = "CaptionSummary",
+    MappingName = "Salary",
+    Format = "{Sum:c}",
+    SummaryType = SummaryType.DoubleAggregate
+});
+sfGrid.CaptionSummaryRow= summaryRow;
+{% endhighlight c#%}
+{% endtabs %}
+
+![DataGrid with caption summary cells customized](Images\caption-summary\maui-datagrid-show-summary-in-column.png)
+
+N> The `CaptionSummaryColumn` text will be aligned based on the `DataGridColumn.TextAlignment`.
+
+### Caption summary template
+
+The data grid allows you to host any view(s) inside a caption summary for the entire row or for individual columns by loading a template. 
+
+### Displaying template for a row
+
+The template for a caption summary row can be customized by using the [SfDataGrid.CaptionSummaryTemplate]() property. This allows you to define a custom template according to your requirements.
+
+Please refer to the code example below, where a label is loaded in the caption summary template of the caption summary row:
+
+{% tabs %}
+{% highlight xaml%}
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <local:GroupCaptionConverter x:Key="SummaryConverter" />
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <sfgrid:SfDataGrid x:Name="dataGrid"
+                       ItemsSource="{Binding OrdersInfo}">
+        <sfgrid:SfDataGrid.CaptionSummaryTemplate>
+            <DataTemplate>
+                <StackLayout Orientation="Horizontal">
+                    <Label Text="{Binding Converter={StaticResource SummaryConverter}, ConverterParameter = {x:ReferencedataGrid} }"
+                           FontSize="Default"
+                           VerticalTextAlignment="Center"
+                           HorizontalTextAlignment="Start"
+                           LineBreakMode="NoWrap"
+                           HorizontalOptions="FillAndExpand"
+                           VerticalOptions="FillAndExpand">
+                        <Label.Style>
+                            <Style TargetType="Label">
+                                <Setter Property="FontAttributes"
+                                        Value="Bold, Italic" />
+                            </Style>
+                        </Label.Style>
+                    </Label>
+                </StackLayout>
+            </DataTemplate>
+        </sfgrid:SfDataGrid.CaptionSummaryTemplate>
+        <sfgrid:SfDataGrid.CaptionSummaryRow>
+            <sfgrid:DataGridSummaryRow Name="CaptionSummary"
+                                       ShowSummaryInRow="True"
+                                       Title="Total Salary: {CaptionSummary}">
+                <sfgrid:DataGridSummaryRow.SummaryColumns>
+                    <sfgrid:DataGridSummaryColumn Name="CaptionSummary"
+                                                  Format="{}{Sum:C0}"
+                                                  MappingName="Salary"
+                                                  SummaryType="DoubleAggregate" />
+                </sfgrid:DataGridSummaryRow.SummaryColumns>
+            </sfgrid:DataGridSummaryRow>
+        </sfgrid:SfDataGrid.CaptionSummaryRow>
+    </sfgrid:SfDataGrid>
+{% endhighlight%}
+{% endtabs %}
+
+{% tabs %}
+{% highlight c# %}
+// To write a converter, follow the code example:
+public class GroupCaptionConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        var data = value != null ? value as Group : null;
+        if (data != null)
+        {
+            SfDataGrid dataGrid = (SfDataGrid)parameter;
+            var summaryText = SummaryCreator.GetSummaryDisplayTextForRow((value as Group).SummaryDetails, dataGrid.View);
+
+            return summaryText;
+        }
+        return null;
+    }
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return null;
+    }
+}
+{% endhighlight %}
+{% endtabs %}
+
+![DataGrid with template loaded for entire caption summary row](Images\caption-summary\maui-datagrid-template-row.png)
+
+N> The `DataTemplateSelector` can also be directly assigned to the `CaptionSummaryTemplate`.
+
+
+### Displaying template for a column
+
+The template for a caption summary column can be customized by using the `DataGridSummaryColumn.Template` property. This allows you to define a custom template according to your requirements.
+
+Here's an example code snippet that demonstrates how to load a label in the template of a caption summary column:
+
+{% tabs %}
+{% highlight xaml%}
+     <ContentPage.Resources>
+         <ResourceDictionary>
+             <local:GroupCaptionConverter x:Key="SummaryConverter" />
+         </ResourceDictionary>
+     </ContentPage.Resources>
+     <sfgrid:SfDataGrid x:Name="dataGrid"
+                       AllowResizingColumn="True"
+                       AutoGenerateColumns="False"
+                       ColumnSizer="Star">
+        <sfgrid:SfDataGrid.Columns>
+            <sfgrid:DataGridTextColumn MappingName="OrderID" />
+            <sfgrid:DataGridTextColumn MappingName="Salary" />
+            <sfgrid:DataGridTextColumn MappingName="CustomerID" />
+        </sfgrid:SfDataGrid.Columns>
+        <sfgrid:SfDataGrid.CaptionSummaryRow>
+            <sfgrid:DataGridSummaryRow Name="CaptionSummary"
+                                       ShowSummaryInRow="False"
+                                       Title="Salary: {CaptionSummary}">
+                <sfgrid:DataGridSummaryRow.SummaryColumns>
+                    <sfgrid:DataGridSummaryColumn Name="CaptionSummary"
+                                                  Format="{}{Sum:C0}"
+                                                  MappingName="Salary"
+                                                  SummaryType="DoubleAggregate">
+                        <sfgrid:DataGridSummaryColumn.Template>
+                            <DataTemplate>
+                                <StackLayout Orientation="Horizontal"
+                                             BackgroundColor="Gray">
+                                    <Label Text="{Binding Converter={StaticResource SummaryConverter}, ConverterParameter {x:ReferencedataGrid} }"
+                                           VerticalOptions="CenterAndExpand"
+                                           TextColor="White"
+                                           FontSize="Default"
+                                           VerticalTextAlignment="Center"
+                                           HorizontalTextAlignment="Start"
+                                           LineBreakMode="NoWrap"
+                                           HorizontalOptions="FillAndExpand">
+                                        <Label.Style>
+                                            <Style TargetType="Label">
+                                                <Setter Property="FontAttributes"
+                                                        Value="Italic" />
+                                            </Style>
+                                        </Label.Style>
+                                    </Label>
+                                </StackLayout>
+                            </DataTemplate>
+                        </sfgrid:DataGridSummaryColumn.Template>
+                    </sfgrid:DataGridSummaryColumn>
+                </sfgrid:DataGridSummaryRow.SummaryColumns>
+            </sfgrid:DataGridSummaryRow>
+        </sfgrid:SfDataGrid.CaptionSummaryRow>
+     </sfgrid:SfDataGrid>
+
+{% endhighlight%}
+{% endtabs %}
+
+{% tabs %}
+{% highlight c# %}
+// To write a converter, follow the code example:
+public class GroupCaptionConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        var data = value != null ? value as Group : null;
+        if (data != null)
+        {
+            SfDataGrid dataGrid = (SfDataGrid)parameter;
+            var summaryText = SummaryCreator.GetSummaryDisplayTextForRow((value as Group).SummaryDetails, dataGrid.View);
+            return summaryText;
+        }
+        return null;
+    }
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return null;
+    }
+}
+{% endhighlight %}
+{% endtabs %}
+
+![DataGrid with template loaded for individual caption summary column](Images\caption-summary\maui-datagrid-template-column.png)
+
+## Group summary
+
+Group summary values are calculated based on the records within each group. The summary information will be displayed at the bottom of each group. You can view the group summary row by expanding the corresponding group header. The data grid allows for the addition of any number of group summary rows.
+
+To add group summary rows in the data grid, you can add the [DataGridSummaryRow]() objects to the [SfDataGrid.GroupSummaryRows]() collection.
+
+### Displaying summary in the row
+
+Summary information can be displayed in the entire row by setting the [DataGridSummaryRow.ShowSummaryInRow]() property to `true` and defining summary columns. The [DataGridSummaryRow.Title]() property needs to be defined based on the [DataGridSummaryRow.Name]() property in order to format the values of the summary columns in a row.
+
+Please refer to the [Formatting Summary]()  section to learn more about how to format the summary.
+
+{% tabs %}
+
+{% highlight xaml %}
+    <sfgrid:SfDataGrid x:Name="dataGrid"
+                       AllowResizingColumn="True"
+                       AllowGroupExpandCollapse="True"
+                       AutoGenerateColumns="True"
+                       ColumnSizer="Star">
+        <sfgrid:SfDataGrid.GroupColumnDescriptions>
+            <sfgrid:GroupColumnDescription ColumnName="Salary" />
+        </sfgrid:SfDataGrid.GroupColumnDescriptions>
+        <sfgrid:SfDataGrid.GroupSummaryRows>
+            <sfgrid:DataGridSummaryRow ShowSummaryInRow="True"
+                                       Title="Total Salary: {Salary} for {customerID} members">
+                <sfgrid:DataGridSummaryRow.SummaryColumns>
+                    <sfgrid:DataGridSummaryColumn Name="Salary"
+                                                  MappingName="Salary"
+                                                  Format="{}{Sum:C0}"
+                                                  SummaryType="DoubleAggregate">
+                    </sfgrid:DataGridSummaryColumn>
+                    <sfgrid:DataGridSummaryColumn Name="customerID"
+                                                  MappingName="CustomerID"
+                                                  Format="{}{Count}"
+                                                  SummaryType="CountAggregate">
+                    </sfgrid:DataGridSummaryColumn>
+                </sfgrid:DataGridSummaryRow.SummaryColumns>
+            </sfgrid:DataGridSummaryRow>
+        </sfgrid:SfDataGrid.GroupSummaryRows>
+    </sfgrid:SfDataGrid>
+{% endhighlight %}
+{% highlight c# %}
+this.dataGrid.GroupSummaryRows.Add(new DataGridSummaryRow()
+{
+    ShowSummaryInRow = true,
+    Title = "Total Salary: {Salary} for {customerID} members",
+    SummaryColumns = new ObservableCollection<ISummaryColumn>()
+    {
+        new DataGridSummaryColumn()
+        {
+            Name="Salary",
+            MappingName="Salary",
+            SummaryType=SummaryType.DoubleAggregate,
+            Format="{Sum}"
+        },
+        new DataGridSummaryColumn()
+        {
+            Name="customerID",
+            MappingName="customerID",
+            Format="{Count}",
+            SummaryType=SummaryType.CountAggregate
+        }
+    }
+});
+{% endhighlight %}
+{% endtabs %}
+
+
+![DataGrid with group summary](Images\group-summary\maui-datagrid-show-summary-in-row.png)
+
+### Displaying summary in the column
+
+The summary information can be displayed in a column by setting the [DataGridSummaryRow.ShowSummaryInRow]() property to `false` and defining summary columns. To calculate the summary based on a column, you need to specify the following properties:
+
+[DataGridSummaryColumn.MappingName](): This property provides the MappingName of the column (the property name of the data object) for which you want to calculate the summary.
+[DataGridSummaryColumn.SummaryType](): This property provides different built-in summary calculation functions for various types.
+[DataGridSummaryColumn.Format](): This property allows you to specify a format string for the summary based on the supported function name in the specified SummaryType.
+
+Please refer to the [Formatting Summary](#formatting-summary) section to learn more about how to format the summary, and the [Aggregate Types](#aggregate-types) section to understand the different Summary Types.
+
+In the following code snippet, a summary is defined for the `Salary` and `CustomerID` columns:
+
+{% tabs %}
+{% highlight xaml %}
+    <sfgrid:SfDataGrid x:Name="dataGrid"
+                       AllowResizingColumn="True"
+                       AutoGenerateColumns="True"
+                       ColumnSizer="Star">
+        <sfgrid:SfDataGrid.GroupSummaryRows>
+            <sfgrid:DataGridSummaryRow ShowSummaryInRow="False">
+                <sfgrid:DataGridSummaryRow.SummaryColumns>
+                    <sfgrid:DataGridSummaryColumn Name="Salary"
+                                                  MappingName="Salary"
+                                                  Format="{}{Sum:C0}"
+                                                  SummaryType="DoubleAggregate">
+                    </sfgrid:DataGridSummaryColumn>
+                </sfgrid:DataGridSummaryRow.SummaryColumns>
+            </sfgrid:DataGridSummaryRow>
+        </sfgrid:SfDataGrid.GroupSummaryRows>
+    </sfgrid:SfDataGrid>
+{% endhighlight %}
+
+{% highlight c# %}
+this.dataGrid.GroupSummaryRows.Add(new DataGridSummaryRow()
+{
+    ShowSummaryInRow = false,
+    SummaryColumns = new ObservableCollection<ISummaryColumn>()
+    {
+        new DataGridSummaryColumn()
+        {
+            Name="Salary",
+            MappingName="Salary",
+            SummaryType=SummaryType.DoubleAggregate,
+            Format="{Sum}"
+        },
+    }
+});
+{% endhighlight %}
+{% endtabs %}
+
+
+![DataGrid with customized summary for group summary cells](Images\group-summary\maui-datagrid-show-summary-in-column.png)
+
+### Group summary template
+
+The data grid allows you to host any view(s) inside a group summary for the entire row or individual columns by loading a template. 
+
+### Displaying template for a row
+
+The template for a group summary row can be customized by using the `SfDataGrid.GroupSummaryTemplate` property.
+
+Refer to the code example below, which demonstrates how to load a label in the group summary template of a group summary row:
+
+{% tabs %}
+{% highlight xaml%}
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <local:GroupSummaryConverter x:Key="SummaryConverter" />
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <sfgrid:SfDataGrid x:Name="dataGrid"
+                       ItemsSource="{Binding OrdersInfo}">
+        <sfgrid:SfDataGrid.GroupSummaryTemplate>
+            <DataTemplate>
+                <StackLayout Orientation="Horizontal">
+                    <Label Text="{Binding Converter={StaticResource SummaryConverter}, ConverterParameter = {x:ReferencedataGrid} }"
+                           FontSize="Default"
+                           VerticalTextAlignment="Center"
+                           HorizontalTextAlignment="Start"
+                           LineBreakMode="NoWrap"
+                           HorizontalOptions="FillAndExpand"
+                           VerticalOptions="FillAndExpand">
+                        <Label.Style>
+                            <Style TargetType="Label">
+                                <Setter Property="FontAttributes"
+                                        Value="Bold, Italic" />
+                            </Style>
+                        </Label.Style>
+                    </Label>
+                </StackLayout>
+            </DataTemplate>
+        </sfgrid:SfDataGrid.GroupSummaryTemplate>
+        <sfgrid:SfDataGrid.GroupSummaryRows>
+            <sfgrid:DataGridSummaryRow Title="salary {Salary}"
+                                       ShowSummaryInRow="True">
+                <sfgrid:DataGridSummaryRow.SummaryColumns>
+                    <sfgrid:DataGridSummaryColumn Name="Salary"
+                                                  MappingName="Salary"
+                                                  Format="{}{Sum:C0}"
+                                                  SummaryType="DoubleAggregate">
+                    </sfgrid:DataGridSummaryColumn>
+                </sfgrid:DataGridSummaryRow.SummaryColumns>
+            </sfgrid:DataGridSummaryRow>
+        </sfgrid:SfDataGrid.GroupSummaryRows>
+    </sfgrid:SfDataGrid>
+{% endhighlight%}
+{% endtabs %}
+
+{% tabs %}
+{% highlight c# %}
+// To write a converter, follow the code example:
+public class GroupSummaryConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        var data = value != null ? value as SummaryRecordEntry : null;
+        if (data != null)
+        {
+            SfDataGrid dataGrid = (SfDataGrid)parameter;
+            var summaryText = SummaryCreator.GetSummaryDisplayText(data,"Salary",dataGrid.View);
+            return "Total Salary:" + " " + summaryText.ToString();
+        }
+        return null;
+    }
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return null;
+    }
+}
+{% endhighlight %}
+{% endtabs %}
+
+![DataGrid with template loaded for entire group summary row](Images\group-summary\maui-datagrid-row-template.png)
+
+N> The `DataTemplateSelector` can also be directly assigned to the `SfDataGrid.GroupSummaryTemplate`.
+
+### Displaying template for a column
+
+The template for a group summary column can be customized by using the `GridSummaryColumn.Template`  property. This allows you to define a custom template according to your requirements.
+
+Please refer to the code example below, which demonstrates how to load a label in the template of a group summary column:
+
+{% tabs %}
+{% highlight xaml%}
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <local:GroupSummaryConverter x:Key="SummaryConverter" />
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <sfgrid:SfDataGrid x:Name="dataGrid"
+                       AllowResizingColumn="True"
+                       AutoGenerateColumns="False"
+                       ColumnSizer="Star">
+        <sfgrid:SfDataGrid.Columns>
+            <sfgrid:DataGridTextColumn MappingName="OrderID" />
+            <sfgrid:DataGridTextColumn MappingName="Salary" />
+            <sfgrid:DataGridTextColumn MappingName="CustomerID" />
+            <sfgrid:DataGridTextColumn MappingName="Country" />
+        </sfgrid:SfDataGrid.Columns>
+        <sfgrid:SfDataGrid.GroupSummaryRows>
+            <sfgrid:DataGridSummaryRow ShowSummaryInRow="False">
+                <sfgrid:DataGridSummaryRow.SummaryColumns>
+                    <sfgrid:DataGridSummaryColumn Name="Salary"
+                                                  MappingName="Salary"
+                                                  Format="{}{Sum:C0}"
+                                                  SummaryType="DoubleAggregate">
+                        <sfgrid:DataGridSummaryColumn.Template>
+                            <DataTemplate>
+                                <StackLayout Orientation="Horizontal"
+                                             BackgroundColor="Gray">
+                                    <Label Text="{Binding Converter={StaticResource SummaryConverter}, ConverterParameter {x:ReferencedataGrid} }"
+                                           VerticalOptions="CenterAndExpand"
+                                           TextColor="White"
+                                           FontSize="Medium"
+                                           VerticalTextAlignment="Center"
+                                           HorizontalTextAlignment="Start"
+                                           LineBreakMode="NoWrap"
+                                           HorizontalOptions="FillAndExpand">
+                                        <Label.Style>
+                                            <Style TargetType="Label">
+                                                <Setter Property="FontAttributes"
+                                                        Value="Italic" />
+                                            </Style>
+                                        </Label.Style>
+                                    </Label>
+                                </StackLayout>
+                            </DataTemplate>
+                        </sfgrid:DataGridSummaryColumn.Template>
+                    </sfgrid:DataGridSummaryColumn>
+                </sfgrid:DataGridSummaryRow.SummaryColumns>
+            </sfgrid:DataGridSummaryRow>
+        </sfgrid:SfDataGrid.GroupSummaryRows>
+    </sfgrid:SfDataGrid>
+{% endhighlight%}
+{% endtabs %}
+
+{% tabs %}
+{% highlight c# %}
+// To write a converter, follow the code example:
+public class GroupSummaryConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        var data = value != null ? value as SummaryRecordEntry : null;
+        if (data != null)
+        {
+            SfDataGrid dataGrid = (SfDataGrid)parameter;
+            var summaryText = SummaryCreator.GetSummaryDisplayText(data,"Salary",dataGrid.View);
+            return summaryText.ToString();
+        }
+        return null;
+    }
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return null;
+    }
+}
+{% endhighlight %}
+{% endtabs %}
+
+![DataGrid with template loaded for individual group summary cell](Images\group-summary\maui-datagrid-column-template.png)
+
+
 ## Table summaries
 
 The data grid provides built-in support for table summaries. The table summary value is calculated based on all records in the control.
@@ -30,34 +635,35 @@ You can add table summary row in the data grid by adding the [DataGridTableSumma
 
 The following screenshot illustrates table summary rows in the data grid:
 
-![DataGrid with table summary](Images\Table-Summary\Summary.png)
+![DataGrid with table summary](Images\table-summary\maui-datagrid-table-summary-position.png)
 
 {% tabs %}
 {% highlight xaml%}
-<sfGrid:SfDataGrid.TableSummaryRows>
-    <sfGrid:DataGridTableSummaryRow Title="Total Salary :{TotalSalary} for {ProductCount} members"
-                                Position="Top"
-                                ShowSummaryInRow="True">
-        <sfGrid:DataGridTableSummaryRow.SummaryColumns>
-            <sfGrid:DataGridSummaryColumn Name="TotalSalary"
-                                      Format="{}{Sum:C0}"
-                                      MappingName="Salary"
-                                      SummaryType="DoubleAggregate" />
-            <sfGrid:DataGridSummaryColumn Name="ProductCount"
-                                      Format="{}{Count}"
-                                      MappingName="Salary"
-                                      SummaryType="CountAggregate" />
-            </sfGrid:DataGridTableSummaryRow.SummaryColumns>
-        </sfGrid:DataGridTableSummaryRow>
-    <sfGrid:DataGridTableSummaryRow Position="Top" ShowSummaryInRow="False">
-        <sfGrid:DataGridTableSummaryRow.SummaryColumns>
-            <sfGrid:DataGridSummaryColumn Name="TotalSalary"
-                                      Format="{}{Sum:C0}"
-                                      MappingName="Salary"
-                                      SummaryType="DoubleAggregate" />
-            </sfGrid:DataGridTableSummaryRow.SummaryColumns>
-        </sfGrid:DataGridTableSummaryRow>
-</sfGrid:SfDataGrid.TableSummaryRows>
+                <sfGrid:SfDataGrid.TableSummaryRows>
+                <sfGrid:DataGridTableSummaryRow Title="Total Salary :{TotalSalary} for {ProductCount} members"
+                                                Position="Top"
+                                                ShowSummaryInRow="True">
+                    <sfGrid:DataGridTableSummaryRow.SummaryColumns>
+                        <sfGrid:DataGridSummaryColumn Name="TotalSalary"
+                                                      Format="{}{Sum:C0}"
+                                                      MappingName="Salary"
+                                                      SummaryType="DoubleAggregate" />
+                        <sfGrid:DataGridSummaryColumn Name="ProductCount"
+                                                      Format="{}{Count}"
+                                                      MappingName="Salary"
+                                                      SummaryType="CountAggregate" />
+                    </sfGrid:DataGridTableSummaryRow.SummaryColumns>
+                </sfGrid:DataGridTableSummaryRow>
+                <sfGrid:DataGridTableSummaryRow Position="Top"
+                                                ShowSummaryInRow="False">
+                    <sfGrid:DataGridTableSummaryRow.SummaryColumns>
+                        <sfGrid:DataGridSummaryColumn Name="TotalSalary"
+                                                      Format="{}{Sum:C0}"
+                                                      MappingName="Salary"
+                                                      SummaryType="DoubleAggregate" />
+                    </sfGrid:DataGridTableSummaryRow.SummaryColumns>
+                </sfGrid:DataGridTableSummaryRow>
+            </sfGrid:SfDataGrid.TableSummaryRows>
 {% endhighlight %}
 
 {% highlight c#%}
@@ -95,7 +701,8 @@ sfGrid.TableSummaryRows.Add(summaryRow2);
 {% endhighlight %}
 {% endtabs %}
 
-![DataGrid with table summary](Images\Table-Summary\TableSummary.png)
+
+![DataGrid with table summary](Images\table-summary\maui-datagrid-table-summary.png)
 
 ### Displaying summary in a row
 
@@ -104,20 +711,20 @@ Display summary information in a row by setting the [DataGridTableSummaryRow.Sho
 {% tabs %}
 {% highlight xaml%}
 <sfGrid:SfDataGrid.TableSummaryRows>
-    <sfGrid:DataGridTableSummaryRow Title="Total Salary :{TotalSalary} for {ProductCount} members"
-                                ShowSummaryInRow="True">
-        <sfGrid:DataGridTableSummaryRow.SummaryColumns>
-            <sfGrid:DataGridSummaryColumn Name="TotalSalary"
-                                      Format="{}{Sum:C0}"
-                                      MappingName="Salary"
-                                      SummaryType="DoubleAggregate" />
-            <sfGrid:DataGridSummaryColumn Name="ProductCount"
-                                      Format="{}{Count}"
-                                      MappingName="Salary"
-                                      SummaryType="CountAggregate" />
-            </sfGrid:DataGridTableSummaryRow.SummaryColumns>
-        </sfGrid:DataGridTableSummaryRow>
-</sfGrid:SfDataGrid.TableSummaryRows>
+                <sfGrid:DataGridTableSummaryRow Title="Total Salary :{TotalSalary} for {ProductCount} members"
+                                                ShowSummaryInRow="True">
+                    <sfGrid:DataGridTableSummaryRow.SummaryColumns>
+                        <sfGrid:DataGridSummaryColumn Name="TotalSalary"
+                                                      Format="{}{Sum:C0}"
+                                                      MappingName="Salary"
+                                                      SummaryType="DoubleAggregate" />
+                        <sfGrid:DataGridSummaryColumn Name="ProductCount"
+                                                      Format="{}{Count}"
+                                                      MappingName="Salary"
+                                                      SummaryType="CountAggregate" />
+                    </sfGrid:DataGridTableSummaryRow.SummaryColumns>
+                </sfGrid:DataGridTableSummaryRow>
+            </sfGrid:SfDataGrid.TableSummaryRows>
 {% endhighlight %}
 
 {% highlight c#%}
@@ -144,7 +751,7 @@ sfGrid.TableSummaryRows.Add(summaryRow);
 
 The following screenshot shows the table summary row if `ShowSummaryInRow` is `true`:
 
-![DataGrid with customized table summary for entire row](Images\Table-Summary\ShowSummaryInRow.png)
+![DataGrid with customized table summary for entire row](Images\table-summary\maui-datagrid-show-summary-in-row.png)
 
 ### Displaying summary in a column
 
@@ -170,16 +777,17 @@ In the following code snippet, summary is defined for `Salary` column:
 
 {% tabs %}
 {% highlight xaml%}
-<sfGrid:SfDataGrid.TableSummaryRows>
-    <sfGrid:DataGridTableSummaryRow Name="TableSummary" ShowSummaryInRow="False">
-        <sfGrid:DataGridTableSummaryRow.SummaryColumns>
-            <sfGrid:DataGridSummaryColumn Name="TableSummary"
-                                      Format="{}{Sum:C0}"
-                                      MappingName="Salary"
-                                      SummaryType="DoubleAggregate" />
-        </sfGrid:DataGridTableSummaryRow.SummaryColumns>
-    </sfGrid:DataGridTableSummaryRow>
-</sfGrid:SfDataGrid.TableSummaryRows>
+            <sfGrid:SfDataGrid.TableSummaryRows>
+                <sfGrid:DataGridTableSummaryRow Name="TableSummary"
+                                                ShowSummaryInRow="False">
+                    <sfGrid:DataGridTableSummaryRow.SummaryColumns>
+                        <sfGrid:DataGridSummaryColumn Name="TableSummary"
+                                                      Format="{}{Sum:C0}"
+                                                      MappingName="Salary"
+                                                      SummaryType="DoubleAggregate" />
+                    </sfGrid:DataGridTableSummaryRow.SummaryColumns>
+                </sfGrid:DataGridTableSummaryRow>
+            </sfGrid:SfDataGrid.TableSummaryRows>
 {% endhighlight %}
 
 {% highlight c#%}
@@ -198,7 +806,7 @@ sfGrid.TableSummaryRows.Add(summaryRow);
 
 The following screenshot shows the table summary row if `ShowSummaryInRow` is `false`.
 
-![DataGrid with customized table summary for individual cells](Images\Table-Summary\ShowSummaryInColumn.png)
+![DataGrid with customized table summary for individual cells](Images\table-summary\maui-datagrid-show-summary-in-column.png)
 
 ### Positioning TableSummaryRows
 
@@ -206,31 +814,31 @@ The data grid add table summary rows either at top or bottom positions using the
 
 {% tabs %}
 {% highlight xaml%}
-<sfGrid:SfDataGrid.TableSummaryRows>
-    <sfGrid:DataGridTableSummaryRow Position="Top"
-                                ShowSummaryInRow="False">
-        <sfGrid:DataGridTableSummaryRow.SummaryColumns>
-            <sfGrid:DataGridSummaryColumn Name="TotalSalary"
-                                      Format="{}{Sum:C0}"
-                                      MappingName="Salary"
-                                      SummaryType="DoubleAggregate" />
-            </sfGrid:DataGridTableSummaryRow.SummaryColumns>
-        </sfGrid:DataGridTableSummaryRow>
-    <sfGrid:DataGridTableSummaryRow Position="Bottom"
-                                ShowSummaryInRow="True"
-                                Title="Total Salary :{TotalSalary} for {ProductCount} members">
-        <sfGrid:DataGridTableSummaryRow.SummaryColumns>
-            <sfGrid:DataGridSummaryColumn Name="TotalSalary"
-                                      Format="{}{Sum:C0}"
-                                      MappingName="Salary"
-                                      SummaryType="DoubleAggregate" />
-            <sfGrid:DataGridSummaryColumn Name="ProductCount"
-                                      Format="{}{Count}"
-                                      MappingName="Salary"
-                                      SummaryType="CountAggregate" />
-        </sfGrid:DataGridTableSummaryRow.SummaryColumns>
-    </sfGrid:DataGridTableSummaryRow>
-</sfGrid:SfDataGrid.TableSummaryRows>
+            <sfGrid:SfDataGrid.TableSummaryRows>
+                <sfGrid:DataGridTableSummaryRow Position="Top"
+                                                ShowSummaryInRow="False">
+                    <sfGrid:DataGridTableSummaryRow.SummaryColumns>
+                        <sfGrid:DataGridSummaryColumn Name="TotalSalary"
+                                                      Format="{}{Sum:C0}"
+                                                      MappingName="Salary"
+                                                      SummaryType="DoubleAggregate" />
+                    </sfGrid:DataGridTableSummaryRow.SummaryColumns>
+                </sfGrid:DataGridTableSummaryRow>
+                <sfGrid:DataGridTableSummaryRow Position="Bottom"
+                                                ShowSummaryInRow="True"
+                                                Title="Total Salary :{TotalSalary} for {ProductCount} members">
+                    <sfGrid:DataGridTableSummaryRow.SummaryColumns>
+                        <sfGrid:DataGridSummaryColumn Name="TotalSalary"
+                                                      Format="{}{Sum:C0}"
+                                                      MappingName="Salary"
+                                                      SummaryType="DoubleAggregate" />
+                        <sfGrid:DataGridSummaryColumn Name="ProductCount"
+                                                      Format="{}{Count}"
+                                                      MappingName="Salary"
+                                                      SummaryType="CountAggregate" />
+                    </sfGrid:DataGridTableSummaryRow.SummaryColumns>
+                </sfGrid:DataGridTableSummaryRow>
+            </sfGrid:SfDataGrid.TableSummaryRows>
 {% endhighlight %}
 
 {% highlight c#%}
@@ -270,7 +878,7 @@ sfGrid.TableSummaryRows.Add(bottomSummaryRow);
 
 The below screenshot illustrates the positioning of table summary rows in SfDataGrid.
 
-![Customizing table summary row position in a DataGrid](Images\Table-Summary\Summary.png)
+![Customizing table summary row position in a DataGrid](Images\table-summary\maui-datagrid-table-summary-position.png)
 
 ## Table summary template
 
@@ -284,67 +892,66 @@ Refer the below code example in which a label is loaded in the table summary tem
 
 {% tabs %}
 {% highlight xaml %}
-
- <ContentPage.Resources>
-        <ResourceDictionary>
-            <local:TableSummaryConverter x:Key="SummaryConverter" />
-        </ResourceDictionary>
-    </ContentPage.Resources>
-    <StackLayout>
-        <sfgrid:SfDataGrid x:Name="dataGrid"
-                           ItemsSource="{Binding OrdersInfo}"
-                           AutoGenerateColumns="False"
-                           AllowEditing="True"
-                           NavigationMode="Cell"
-                           SelectionMode="Single"
-                           ColumnSizer="Star">
-            <sfgrid:SfDataGrid.Columns>
-                <sfgrid:GridNumericColumn MappingName="OrderID" />
-                <sfgrid:GridTextColumn MappingName="EmployeeID" />
-                <sfgrid:GridTextColumn MappingName="FirstName"  />
-                <sfgrid:GridTextColumn MappingName="LastName"  />
-            </sfgrid:SfDataGrid.Columns>
-            <sfgrid:SfDataGrid.TableSummaryTemplate>
-                <DataTemplate>
-                        <StackLayout Orientation="Horizontal" BackgroundColor="Gray">
-                            <Label Text="{Binding Converter={StaticResource SummaryConverter}, ConverterParameter = {x:Reference dataGrid} }"
-                                   TextColor="White"
-                                   FontSize="Large"
-                                   VerticalTextAlignment="Center"
-                                   HorizontalTextAlignment="Start"
-                                   LineBreakMode="NoWrap"
-                                   HorizontalOptions="FillAndExpand"
-                                   VerticalOptions="FillAndExpand">
-                                <Label.Style>
-                                    <Style TargetType="Label">
-                                        <Setter Property="FontAttributes" Value="Italic" />
-                                    </Style>
-                                </Label.Style>
-                            </Label>
-                        </StackLayout>
-                </DataTemplate>
-            </sfgrid:SfDataGrid.TableSummaryTemplate>
-            <sfgrid:SfDataGrid.TableSummaryRows>
-                <sfgrid:DataGridTableSummaryRow Title="Total Salary :{TotalSalary} for {ProductCount} members"
-                                            Position="Bottom"
-                                            ShowSummaryInRow="True">
-                    <sfgrid:DataGridTableSummaryRow.SummaryColumns>
-                        <sfgrid:DataGridSummaryColumn Name="TotalSalary"
-                                                  Format="{}{Sum:C0}"
-                                                  MappingName="Salary"
-                                                  SummaryType="DoubleAggregate" />
-                    </sfgrid:DataGridTableSummaryRow.SummaryColumns>
-                </sfgrid:DataGridTableSummaryRow>
-            </sfgrid:SfDataGrid.TableSummaryRows>
-        </sfgrid:SfDataGrid>
-    </StackLayout>
-
+            <ContentPage.Resources>
+                <ResourceDictionary>
+                    <local:TableSummaryConverter x:Key="SummaryConverter" />
+                </ResourceDictionary>
+            </ContentPage.Resources>
+            <StackLayout>
+                <sfgrid:SfDataGrid x:Name="dataGrid"
+                                   ItemsSource="{Binding OrdersInfo}"
+                                   AutoGenerateColumns="False"
+                                   AllowEditing="True"
+                                   NavigationMode="Cell"
+                                   SelectionMode="Single"
+                                   ColumnSizer="Star">
+                    <sfgrid:SfDataGrid.Columns>
+                        <sfgrid:GridNumericColumn MappingName="OrderID" />
+                        <sfgrid:GridTextColumn MappingName="EmployeeID" />
+                        <sfgrid:GridTextColumn MappingName="FirstName" />
+                        <sfgrid:GridTextColumn MappingName="LastName" />
+                    </sfgrid:SfDataGrid.Columns>
+                    <sfgrid:SfDataGrid.TableSummaryTemplate>
+                        <DataTemplate>
+                            <StackLayout Orientation="Horizontal"
+                                         BackgroundColor="Gray">
+                                <Label Text="{Binding Converter={StaticResource SummaryConverter}, ConverterParameter = {x:Reference dataGrid} }"
+                                       TextColor="White"
+                                       FontSize="Large"
+                                       VerticalTextAlignment="Center"
+                                       HorizontalTextAlignment="Start"
+                                       LineBreakMode="NoWrap"
+                                       HorizontalOptions="FillAndExpand"
+                                       VerticalOptions="FillAndExpand">
+                                    <Label.Style>
+                                        <Style TargetType="Label">
+                                            <Setter Property="FontAttributes"
+                                                    Value="Italic" />
+                                        </Style>
+                                    </Label.Style>
+                                </Label>
+                            </StackLayout>
+                        </DataTemplate>
+                    </sfgrid:SfDataGrid.TableSummaryTemplate>
+                    <sfgrid:SfDataGrid.TableSummaryRows>
+                        <sfgrid:DataGridTableSummaryRow Title="Total Salary :{TotalSalary} for {ProductCount} members"
+                                                        Position="Bottom"
+                                                        ShowSummaryInRow="True">
+                            <sfgrid:DataGridTableSummaryRow.SummaryColumns>
+                                <sfgrid:DataGridSummaryColumn Name="TotalSalary"
+                                                              Format="{}{Sum:C0}"
+                                                              MappingName="Salary"
+                                                              SummaryType="DoubleAggregate" />
+                            </sfgrid:DataGridTableSummaryRow.SummaryColumns>
+                        </sfgrid:DataGridTableSummaryRow>
+                    </sfgrid:SfDataGrid.TableSummaryRows>
+                </sfgrid:SfDataGrid>
+            </StackLayout>
 {% endhighlight %}
 {% endtabs %}
 
 {% tabs %}
 {% highlight c# %}
-
  public class TableSummaryConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
@@ -365,11 +972,10 @@ Refer the below code example in which a label is loaded in the table summary tem
         return null;
     }
 }
-
 {% endhighlight %}
 {% endtabs %}
 
-![Table summary template in a row](Images\Table-Summary\TemplateRow.png)
+![Table summary template in a row](Images\table-summary\maui-datagrid-template-row.png)
 
 ### Displaying template for a column
 
@@ -379,95 +985,93 @@ Refer the below code example in which a label is loaded in the template of table
 
 {% tabs %}
 {% highlight xaml%}
-
-<ContentPage.Resources>
-        <ResourceDictionary>
-            <local:TableSummaryConverter x:Key="SummaryConverter" />
-        </ResourceDictionary>
-    </ContentPage.Resources>
-    <StackLayout>
-        <sfgrid:SfDataGrid x:Name="dataGrid"
-                           ItemsSource="{Binding OrdersInfo}"
-                           AutoGenerateColumns="False"
-                           AllowEditing="True"
-                           NavigationMode="Cell"
-                           SelectionMode="Single"
-                           ColumnSizer="Star">
-            <sfgrid:SfDataGrid.Columns>
-                <sfgrid:GridNumericColumn MappingName="OrderID" />
-                <sfgrid:GridTextColumn MappingName="EmployeeID" />
-                <sfgrid:GridTextColumn MappingName="FirstName" />
-                <sfgrid:GridTextColumn MappingName="LastName" />
-            </sfgrid:SfDataGrid.Columns>
-            <sfgrid:SfDataGrid.TableSummaryRows>
-                <sfgrid:DataGridTableSummaryRow Title="Total Salary :{TotalSalary} for {ProductCount} members"
-                                            Position="Bottom"
-                                            ShowSummaryInRow="False">
-                        <sfgrid:DataGridTableSummaryRow.SummaryColumns>
-                            <sfgrid:DataGridSummaryColumn Name="TotalSalary"
-                                                      Format="{}{Sum:C0}"
-                                                      MappingName="Salary"
-                                                      SummaryType="DoubleAggregate" >
-                                <sfgrid:DataGridSummaryColumn.Template>
-                                 <DataTemplate>
-                                    <StackLayout Orientation="Horizontal" BackgroundColor="Gray">
-                                        <Label Text="{Binding Converter={StaticResource SummaryConverter}, ConverterParameter = {x:Reference dataGrid} }"
-                                               TextColor="White"
-                                               FontSize="Medium"
-                                               VerticalTextAlignment="Center"
-                                               HorizontalTextAlignment="Start"
-                                               LineBreakMode="NoWrap"
-                                               HorizontalOptions="FillAndExpand"
-                                               VerticalOptions="FillAndExpand">
-                                            <Label.Style>
-                                                <Style TargetType="Label">
-                                                    <Setter Property="FontAttributes" Value="Italic" />
-                                                </Style>
-                                            </Label.Style>
-                                        </Label>
-                                    </StackLayout>
-                                 </DataTemplate>
-                                </sfgrid:DataGridSummaryColumn.Template>
-                            </sfgrid:DataGridSummaryColumn>
-                        </sfgrid:DataGridTableSummaryRow.SummaryColumns>
-                    </sfgrid:DataGridTableSummaryRow>
-            </sfgrid:SfDataGrid.TableSummaryRows>            
-        </sfgrid:SfDataGrid>
-    </StackLayout>
-
+            <ContentPage.Resources>
+                <ResourceDictionary>
+                    <local:TableSummaryConverter x:Key="SummaryConverter" />
+                </ResourceDictionary>
+            </ContentPage.Resources>
+            <StackLayout>
+                <sfgrid:SfDataGrid x:Name="dataGrid"
+                                   ItemsSource="{Binding OrdersInfo}"
+                                   AutoGenerateColumns="False"
+                                   AllowEditing="True"
+                                   NavigationMode="Cell"
+                                   SelectionMode="Single"
+                                   ColumnSizer="Star">
+                    <sfgrid:SfDataGrid.Columns>
+                        <sfgrid:GridNumericColumn MappingName="OrderID" />
+                        <sfgrid:GridTextColumn MappingName="EmployeeID" />
+                        <sfgrid:GridTextColumn MappingName="FirstName" />
+                        <sfgrid:GridTextColumn MappingName="LastName" />
+                    </sfgrid:SfDataGrid.Columns>
+                    <sfgrid:SfDataGrid.TableSummaryRows>
+                        <sfgrid:DataGridTableSummaryRow Title="Total Salary :{TotalSalary} for {ProductCount} members"
+                                                        Position="Bottom"
+                                                        ShowSummaryInRow="False">
+                            <sfgrid:DataGridTableSummaryRow.SummaryColumns>
+                                <sfgrid:DataGridSummaryColumn Name="TotalSalary"
+                                                              Format="{}{Sum:C0}"
+                                                              MappingName="Salary"
+                                                              SummaryType="DoubleAggregate">
+                                    <sfgrid:DataGridSummaryColumn.Template>
+                                        <DataTemplate>
+                                            <StackLayout Orientation="Horizontal"
+                                                         BackgroundColor="Gray">
+                                                <Label Text="{Binding Converter={StaticResource SummaryConverter}, ConverterParameter = {x:Reference dataGrid} }"
+                                                       TextColor="White"
+                                                       FontSize="Medium"
+                                                       VerticalTextAlignment="Center"
+                                                       HorizontalTextAlignment="Start"
+                                                       LineBreakMode="NoWrap"
+                                                       HorizontalOptions="FillAndExpand"
+                                                       VerticalOptions="FillAndExpand">
+                                                    <Label.Style>
+                                                        <Style TargetType="Label">
+                                                            <Setter Property="FontAttributes"
+                                                                    Value="Italic" />
+                                                        </Style>
+                                                    </Label.Style>
+                                                </Label>
+                                            </StackLayout>
+                                        </DataTemplate>
+                                    </sfgrid:DataGridSummaryColumn.Template>
+                                </sfgrid:DataGridSummaryColumn>
+                            </sfgrid:DataGridTableSummaryRow.SummaryColumns>
+                        </sfgrid:DataGridTableSummaryRow>
+                    </sfgrid:SfDataGrid.TableSummaryRows>
+                </sfgrid:SfDataGrid>
+            </StackLayout>
 {% endhighlight%}
 {% endtabs %}
 
 {% tabs %}
 {% highlight c# %}
-
 // To write a converter, follow the code example:
-
-  public class TableSummaryConverter : IValueConverter
+public class TableSummaryConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        var data = value != null ? value as SummaryRecordEntry : null;
+        if (data != null)
         {
-            var data = value != null ? value as SummaryRecordEntry : null;
-            if (data != null)
-            {
-                SfDataGrid dataGrid = (SfDataGrid)parameter;
-                var summaryText = SummaryCreator.GetSummaryDisplayText(data, "Salary", dataGrid.View);
+            SfDataGrid dataGrid = (SfDataGrid)parameter;
+            var summaryText = SummaryCreator.GetSummaryDisplayText(data, "Salary", dataGrid.View);
 
-                return summaryText.ToString();
-            }
-
-            return null;
+            return summaryText.ToString();
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            return null;
-        }    
+        return null;
     }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return null;
+    }    
+}
 {% endhighlight %}
 {% endtabs %}
 
-![Table summary template in a column](Images\Table-Summary\TemplateColumn.png)
+![Table summary template in a column](Images\table-summary\maui-datagrid-template-column.png)
 
 N> The `DataTemplateSelector` can also be directly assigned to the `SfDataGrid.TableSummaryTemplate`.
 
@@ -483,16 +1087,16 @@ In the following code snippet `Salary` column summary is formatted using `C0` fo
 
 {% tabs %}
 {% highlight xaml%}
-<sfGrid:SfDataGrid.TableSummaryRows>
-    <sfGrid:DataGridTableSummaryRow ShowSummaryInRow="False">
-        <sfGrid:DataGridTableSummaryRow.SummaryColumns>
-            <sfGrid:DataGridSummaryColumn Name="TableSummary"
-                                      Format="{}{Sum:C0}"
-                                      MappingName="Salary"
-                                      SummaryType="DoubleAggregate" />
-        </sfGrid:DataGridTableSummaryRow.SummaryColumns>
-    </sfGrid:DataGridTableSummaryRow>
-</sfGrid:SfDataGrid.TableSummaryRows>
+            <sfGrid:SfDataGrid.TableSummaryRows>
+                <sfGrid:DataGridTableSummaryRow ShowSummaryInRow="False">
+                    <sfGrid:DataGridTableSummaryRow.SummaryColumns>
+                        <sfGrid:DataGridSummaryColumn Name="TableSummary"
+                                                      Format="{}{Sum:C0}"
+                                                      MappingName="Salary"
+                                                      SummaryType="DoubleAggregate" />
+                    </sfGrid:DataGridTableSummaryRow.SummaryColumns>
+                </sfGrid:DataGridTableSummaryRow>
+            </sfGrid:SfDataGrid.TableSummaryRows>
 {% endhighlight %}
 
 {% highlight c#%}
@@ -509,7 +1113,7 @@ sfGrid.TableSummaryRows= summaryRow;
 {% endhighlight %}
 {% endtabs %}
 
-![Formatting summary value in a DataGrid](Images\Table-Summary\ShowSummaryInColumn.png)
+![Formatting summary value in a DataGrid](Images\table-summary\maui-datagrid-show-summary-in-column.png)
 
 
 ### Displaying additional content in summary
@@ -520,16 +1124,16 @@ In the following code snippet `Total:` text is appended before summary value:
 
 {% tabs %}
 {% highlight xaml%}
-<sfGrid:SfDataGrid.TableSummaryRows>
-    <sfGrid:DataGridTableSummaryRow ShowSummaryInRow="False">
-        <sfGrid:DataGridTableSummaryRow.SummaryColumns>
-            <sfGrid:DataGridSummaryColumn Name="TableSummary"
-                                      Format="Total: {Sum:C0}"
-                                      MappingName="Salary"
-                                      SummaryType="DoubleAggregate" />
-        </sfGrid:DataGridTableSummaryRow.SummaryColumns>
-    </sfGrid:DataGridTableSummaryRow>
-</sfGrid:SfDataGrid.TableSummaryRows>
+            <sfGrid:SfDataGrid.TableSummaryRows>
+                <sfGrid:DataGridTableSummaryRow ShowSummaryInRow="False">
+                    <sfGrid:DataGridTableSummaryRow.SummaryColumns>
+                        <sfGrid:DataGridSummaryColumn Name="TableSummary"
+                                                      Format="Total: {Sum:C0}"
+                                                      MappingName="Salary"
+                                                      SummaryType="DoubleAggregate" />
+                    </sfGrid:DataGridTableSummaryRow.SummaryColumns>
+                </sfGrid:DataGridTableSummaryRow>
+            </sfGrid:SfDataGrid.TableSummaryRows>
 {% endhighlight %}
 
 {% highlight c#%}
@@ -546,7 +1150,7 @@ sfGrid.TableSummaryRows= summaryRow;
 {% endhighlight %}
 {% endtabs %}
 
-![Displaying additional content in summary in a DataGrid](Images\Table-Summary\AdditionalContent.png)
+![Displaying additional content in summary in a DataGrid](Images\table-summary\maui-datagrid-additional-content.png)
 
 ## Aggregate types
 
@@ -662,17 +1266,18 @@ Assign the custom aggregate to `DataGridSummaryColumn.CustomAggregate` property 
 
 {% tabs %}
 {% highlight xaml%}
-<sfGrid:SfDataGrid.TableSummaryRows>
-    <sfGrid:DataGridTableSummaryRow Title="Standard Deviation:{TableSummary}" ShowSummaryInRow = "True">                                                     
-        <sfGrid:DataGridTableSummaryRow.SummaryColumns>
-            <sfGrid:DataGridSummaryColumn Name="TableSummary"
-                                      CustomAggregate="{StaticResource customAggregate}"
-                                      Format="{}{StdDev}"
-                                      MappingName="OrderID"
-                                      SummaryType="Custom" />
-        </sfGrid:DataGridTableSummaryRow.SummaryColumns>
-    </sfGrid:DataGridTableSummaryRow>
-</sfGrid:SfDataGrid.TableSummaryRows>
+            <sfGrid:SfDataGrid.TableSummaryRows>
+                <sfGrid:DataGridTableSummaryRow Title="Standard Deviation:{TableSummary}"
+                                                ShowSummaryInRow="True">
+                    <sfGrid:DataGridTableSummaryRow.SummaryColumns>
+                        <sfGrid:DataGridSummaryColumn Name="TableSummary"
+                                                      CustomAggregate="{StaticResource customAggregate}"
+                                                      Format="{}{StdDev}"
+                                                      MappingName="OrderID"
+                                                      SummaryType="Custom" />
+                    </sfGrid:DataGridTableSummaryRow.SummaryColumns>
+                </sfGrid:DataGridTableSummaryRow>
+            </sfGrid:SfDataGrid.TableSummaryRows>
 {% endhighlight %}
 
 {% highlight c#%}
@@ -691,7 +1296,7 @@ dataGrid.TableSummaryRows = summaryRow;
 {% endhighlight %}
 {% endtabs %}
 
-![DataGrid with custom aggregate](Images\Table-Summary\CustomAggregate.png)
+![DataGrid with custom aggregate](Images\table-summary\maui-datagrid-custom-aggregate.png)
 
 N> The above custom summaries section is explained using `TableSummary`.
 
@@ -711,7 +1316,7 @@ Each summary has a specific key using which the custom summary renderer can be r
 
 <tr>
 <td>Table summary</td>
-<td><a href="">DataDataGridTableSummaryCellRenderer</a> </td>
+<td><a href=</a> </td>
 <td>TableSummary</td>
 </tr>
 
@@ -727,22 +1332,20 @@ To customize the table summary, follow the code example:
 
 {% tabs %}
 {% highlight c#%}
-
 // To remove default summary and Add custom summary.
-
 public class Summary : ContentPage
 {
     public Summary()
     {
         InitializeComponent();
         dataGrid.CellRenderers.Remove("TableSummary");
-        dataGrid.CellRenderers.Add("TableSummary", new DataDataGridTableSummaryCellRendererExt());
+        dataGrid.CellRenderers.Add("TableSummary", new DataGridTableSummaryCellRendererExt());
     }
 }
 
-public class DataDataGridTableSummaryCellRendererExt : DataDataGridTableSummaryCellRenderer
+public class DataGridTableSummaryCellRendererExt : DataGridTableSummaryCellRenderer
 {
-    public DataDataGridTableSummaryCellRendererExt()
+    public DataGridTableSummaryCellRendererExt()
     {
     }
 
@@ -750,9 +1353,9 @@ public class DataDataGridTableSummaryCellRendererExt : DataDataGridTableSummaryC
     {
         base.OnInitializeDisplayView(dataColumn, view);
         view.HorizontalTextAlignment = TextAlignment.Start;
-        view.BackgroundColor = Color.DarkCyan;
+        view.BackgroundColor = Colors.DarkCyan;
         view.FontSize = 16;
-        view.TextColor = Color.White;
+        view.TextColor = Colors.White;
 
     }
 }
@@ -761,4 +1364,4 @@ public class DataDataGridTableSummaryCellRendererExt : DataDataGridTableSummaryC
 
 The following screenshot shows the final outcome upon execution of the above code.
 
-![Customize table summary using custom cell renderer](Images\Table-Summary\CustomizingTableSummary.png)
+![Customize table summary using custom cell renderer](Images\table-summary\maui-datagrid-customizing-table-summary.png)

--- a/MAUI/DataGrid/summaries.md
+++ b/MAUI/DataGrid/summaries.md
@@ -11,6 +11,8 @@ documentation: UG
 
 The data grid supports to display the concise information about the bound data objects using summaries. The control provides the following summary types:
 
+* **Caption Summary** - Used to display the summary information in the caption of the group.
+* **Group Summary** - Used to display summary information of data objects in each group.
 * **Table Summary** - Used to display the summary information at top and/or bottom in SfDataGrid.
 
 
@@ -22,6 +24,609 @@ Derive additional information from the data like sum, average, maximum, minimum,
 
 N> The Summary does not refresh with data. To update the summary for the newly added row, or for the modified summary column, set the [SfDataGrid.View.LiveDataUpdateMode](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Data.LiveDataUpdateMode.html) to `LiveDataUpdateMode.AllowDataShaping` or `LiveDataUpdateMode.AllowSummaryUpdate`.
 
+## Caption summaries
+
+The data grid provides built-in support for caption summaries. The caption summary value calculated based on the records in a group. The summary information will be displayed in the caption of group.
+
+### Formatting built-in caption summary
+
+By default, the caption summary rows in the data grid are displayed using the [SfDataGrid.GroupCaptionTextFormat]() property.
+
+Default group caption format is `{ColumnName}: {Key} - {ItemsCount} Items`.
+
+* **ColumnName**: Displays the name of the currently grouped column.
+* **Key**: Displays the key value of the group.
+* **ItemsCount**: Displays the number of items in a group.
+
+![DataGrid with formatting in caption summary row](Images\caption-summary\maui-datagrid-default.png)
+
+You can customize the group caption text format by setting the `SfDataGrid.GroupCaptionTextFormat` property. The code example below illustrates how to customize the group caption text in the data grid:
+
+{% tabs %}
+{% highlight xaml%}
+    <sfGrid:SfDataGrid x:Name="dataGrid"
+                       AutoGenerateColumns="True"
+                       ColumnSizer="Star"
+                       GroupCaptionTextFormat="{}{ColumnName}: {Key}">
+{% endhighlight %}
+
+{% highlight c#%}
+// Customized group caption text
+dataGrid.GroupCaptionTextFormat = "{ColumnName} : {Key}";
+{% endhighlight %}
+{% endtabs %}
+
+The following screenshot shows the outcome of the previous code:
+
+![DataGrid with formatting in caption summary row](Images\caption-summary\maui-datagrid-formatting-show-summary-in-row.png)
+
+
+### Displaying summary for a row
+
+Display summary information in a row by setting the [DataGridSummaryRow.ShowSummaryInRow]() property to `true` and define summary columns. You have to define the [DataGridSummaryRow.Title]() based on the [DataGridSummaryColumn.Name]() property in order to format the values of the summary columns in the row.
+
+{% tabs %}
+{% highlight xaml%}
+    <sfGrid:SfDataGrid.CaptionSummaryRow>
+        <sfGrid:DataGridSummaryRow Title="Total Salary :{TotalSalary} for {ProductCount} members"
+                                   ShowSummaryInRow="True">
+            <sfGrid:DataGridSummaryRow.SummaryColumns>
+                <sfGrid:DataGridSummaryColumn Name="TotalSalary"
+                                              Format="{}{Sum:C0}"
+                                              MappingName="Salary"
+                                              SummaryType="Int32Aggregate" />
+                <sfGrid:DataGridSummaryColumn Name="ProductCount"
+                                              Format="{}{Count}"
+                                              MappingName="Salary"
+                                              SummaryType="CountAggregate" />
+            </sfGrid:DataGridSummaryRow.SummaryColumns>
+        </sfGrid:DataGridSummaryRow>
+    </sfGrid:SfDataGrid.CaptionSummaryRow>
+{% endhighlight %}
+
+{% highlight c#%}
+DataGridSummaryRow summaryRow = new DataGridSummaryRow();
+summaryRow.Title = "Total Salary:{TotalSalary} for {ProductCount} members";
+summaryRow.ShowSummaryInRow = true;
+summaryRow.SummaryColumns.Add(new DataGridSummaryColumn()
+{
+    Name = "TotalSalary",
+    MappingName = "Salary",
+    Format = "{Sum:c}",
+    SummaryType = SummaryType.DoubleAggregate
+});
+summaryRow.SummaryColumns.Add(new DataGridSummaryColumn()
+{
+    Name = "ProductCount",
+    MappingName = "Salary",
+    Format = "{Count}",
+    SummaryType = SummaryType.CountAggregate
+});
+sfGrid.CaptionSummaryRow= summaryRow;
+{% endhighlight %}
+{% endtabs %}
+
+The following screenshot shows the outcome for both values of `ShowSummaryInRow` to `true`:
+
+![DataGrid with customized caption summary row](Images\caption-summary\maui-datagrid-show-summary-in-row.png)
+
+
+### Displaying summary for column
+
+To display summary information in a column, you need to set the `DataGridSummaryRow.ShowSummaryInRow` to `false` and define summary columns using the `SfDataGrid.DataGridSummaryColumn` object. The `DataGridSummaryColumn` object has several important properties:
+
+* [Name](): This property defines the name of the `DataGridSummaryColumn`, which is used to identify the column in the `DataGridSummaryRow` and provide a title for it.
+* [MappingName](): This property defines the corresponding column name used for the summary calculation.
+* [SummaryType]():  This property defines the `SummaryType` enum property, which determines the type of aggregate function used for the summary calculation. 
+
+The DataGrid control provides several predefined aggregates, such as CountAggregate, Int32Aggregate, and DoubleAggregate. When the summary type is set as Custom, you can define a CustomAggregate class object to calculate custom summaries.
+
+The [Format]() property defines a string property that formats the summary value and displays it. The Format property can have two parts separated by a colon (:). The first part denotes the aggregate function name, and the second part denotes the display format of the summary value.
+
+Please refer to the "Formatting Summary" section for more information on how to format the summary, and the "Aggregate Types" section to learn about the different summary types.
+
+In the following code snippet, a summary is defined for the `Salary` column:
+
+{% tabs %}
+{% highlight xaml%}
+    <sfGrid:SfDataGrid.CaptionSummaryRow>
+        <sfGrid:DataGridSummaryRow Name="CaptionSummary"
+                                   ShowSummaryInRow="False">
+            <sfGrid:DataGridSummaryRow.SummaryColumns>
+                <sfGrid:DataGridSummaryColumn Name="CaptionSummary"
+                                              Format="{}{Sum:C0}"
+                                              MappingName="Salary"
+                                              SummaryType="DoubleAggregate" />
+            </sfGrid:DataGridSummaryRow.SummaryColumns>
+        </sfGrid:DataGridSummaryRow>
+    </sfGrid:SfDataGrid.CaptionSummaryRow>
+{% endhighlight %}
+
+{% highlight c#%}
+DataGridSummaryRow summaryRow = new DataGridSummaryRow();
+summaryRow.ShowSummaryInRow = false;
+summaryRow.SummaryColumns.Add(new DataGridSummaryColumn()
+{
+    Name = "CaptionSummary",
+    MappingName = "Salary",
+    Format = "{Sum:c}",
+    SummaryType = SummaryType.DoubleAggregate
+});
+sfGrid.CaptionSummaryRow= summaryRow;
+{% endhighlight c#%}
+{% endtabs %}
+
+![DataGrid with caption summary cells customized](Images\caption-summary\maui-datagrid-show-summary-in-column.png)
+
+N> The `CaptionSummaryColumn` text will be aligned based on the `DataGridColumn.TextAlignment`.
+
+### Caption summary template
+
+The data grid allows you to host any view(s) inside a caption summary for the entire row or for individual columns by loading a template. 
+
+### Displaying template for a row
+
+The template for a caption summary row can be customized by using the [SfDataGrid.CaptionSummaryTemplate]() property. This allows you to define a custom template according to your requirements.
+
+Please refer to the code example below, where a label is loaded in the caption summary template of the caption summary row:
+
+{% tabs %}
+{% highlight xaml%}
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <local:GroupCaptionConverter x:Key="SummaryConverter" />
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <sfgrid:SfDataGrid x:Name="dataGrid"
+                       ItemsSource="{Binding OrdersInfo}">
+        <sfgrid:SfDataGrid.CaptionSummaryTemplate>
+            <DataTemplate>
+                <StackLayout Orientation="Horizontal">
+                    <Label Text="{Binding Converter={StaticResource SummaryConverter}, ConverterParameter = {x:ReferencedataGrid} }"
+                           FontSize="Default"
+                           VerticalTextAlignment="Center"
+                           HorizontalTextAlignment="Start"
+                           LineBreakMode="NoWrap"
+                           HorizontalOptions="FillAndExpand"
+                           VerticalOptions="FillAndExpand">
+                        <Label.Style>
+                            <Style TargetType="Label">
+                                <Setter Property="FontAttributes"
+                                        Value="Bold, Italic" />
+                            </Style>
+                        </Label.Style>
+                    </Label>
+                </StackLayout>
+            </DataTemplate>
+        </sfgrid:SfDataGrid.CaptionSummaryTemplate>
+        <sfgrid:SfDataGrid.CaptionSummaryRow>
+            <sfgrid:DataGridSummaryRow Name="CaptionSummary"
+                                       ShowSummaryInRow="True"
+                                       Title="Total Salary: {CaptionSummary}">
+                <sfgrid:DataGridSummaryRow.SummaryColumns>
+                    <sfgrid:DataGridSummaryColumn Name="CaptionSummary"
+                                                  Format="{}{Sum:C0}"
+                                                  MappingName="Salary"
+                                                  SummaryType="DoubleAggregate" />
+                </sfgrid:DataGridSummaryRow.SummaryColumns>
+            </sfgrid:DataGridSummaryRow>
+        </sfgrid:SfDataGrid.CaptionSummaryRow>
+    </sfgrid:SfDataGrid>
+{% endhighlight%}
+{% endtabs %}
+
+{% tabs %}
+{% highlight c# %}
+// To write a converter, follow the code example:
+public class GroupCaptionConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        var data = value != null ? value as Group : null;
+        if (data != null)
+        {
+            SfDataGrid dataGrid = (SfDataGrid)parameter;
+            var summaryText = SummaryCreator.GetSummaryDisplayTextForRow((value as Group).SummaryDetails, dataGrid.View);
+
+            return summaryText;
+        }
+        return null;
+    }
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return null;
+    }
+}
+{% endhighlight %}
+{% endtabs %}
+
+![DataGrid with template loaded for entire caption summary row](Images\caption-summary\maui-datagrid-template-row.png)
+
+N> The `DataTemplateSelector` can also be directly assigned to the `CaptionSummaryTemplate`.
+
+
+### Displaying template for a column
+
+The template for a caption summary column can be customized by using the `DataGridSummaryColumn.Template` property. This allows you to define a custom template according to your requirements.
+
+Here's an example code snippet that demonstrates how to load a label in the template of a caption summary column:
+
+{% tabs %}
+{% highlight xaml%}
+     <ContentPage.Resources>
+         <ResourceDictionary>
+             <local:GroupCaptionConverter x:Key="SummaryConverter" />
+         </ResourceDictionary>
+     </ContentPage.Resources>
+     <sfgrid:SfDataGrid x:Name="dataGrid"
+                       AllowResizingColumn="True"
+                       AutoGenerateColumns="False"
+                       ColumnSizer="Star">
+        <sfgrid:SfDataGrid.Columns>
+            <sfgrid:DataGridTextColumn MappingName="OrderID" />
+            <sfgrid:DataGridTextColumn MappingName="Salary" />
+            <sfgrid:DataGridTextColumn MappingName="CustomerID" />
+        </sfgrid:SfDataGrid.Columns>
+        <sfgrid:SfDataGrid.CaptionSummaryRow>
+            <sfgrid:DataGridSummaryRow Name="CaptionSummary"
+                                       ShowSummaryInRow="False"
+                                       Title="Salary: {CaptionSummary}">
+                <sfgrid:DataGridSummaryRow.SummaryColumns>
+                    <sfgrid:DataGridSummaryColumn Name="CaptionSummary"
+                                                  Format="{}{Sum:C0}"
+                                                  MappingName="Salary"
+                                                  SummaryType="DoubleAggregate">
+                        <sfgrid:DataGridSummaryColumn.Template>
+                            <DataTemplate>
+                                <StackLayout Orientation="Horizontal"
+                                             BackgroundColor="Gray">
+                                    <Label Text="{Binding Converter={StaticResource SummaryConverter}, ConverterParameter {x:ReferencedataGrid} }"
+                                           VerticalOptions="CenterAndExpand"
+                                           TextColor="White"
+                                           FontSize="Default"
+                                           VerticalTextAlignment="Center"
+                                           HorizontalTextAlignment="Start"
+                                           LineBreakMode="NoWrap"
+                                           HorizontalOptions="FillAndExpand">
+                                        <Label.Style>
+                                            <Style TargetType="Label">
+                                                <Setter Property="FontAttributes"
+                                                        Value="Italic" />
+                                            </Style>
+                                        </Label.Style>
+                                    </Label>
+                                </StackLayout>
+                            </DataTemplate>
+                        </sfgrid:DataGridSummaryColumn.Template>
+                    </sfgrid:DataGridSummaryColumn>
+                </sfgrid:DataGridSummaryRow.SummaryColumns>
+            </sfgrid:DataGridSummaryRow>
+        </sfgrid:SfDataGrid.CaptionSummaryRow>
+     </sfgrid:SfDataGrid>
+
+{% endhighlight%}
+{% endtabs %}
+
+{% tabs %}
+{% highlight c# %}
+// To write a converter, follow the code example:
+public class GroupCaptionConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        var data = value != null ? value as Group : null;
+        if (data != null)
+        {
+            SfDataGrid dataGrid = (SfDataGrid)parameter;
+            var summaryText = SummaryCreator.GetSummaryDisplayTextForRow((value as Group).SummaryDetails, dataGrid.View);
+            return summaryText;
+        }
+        return null;
+    }
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return null;
+    }
+}
+{% endhighlight %}
+{% endtabs %}
+
+![DataGrid with template loaded for individual caption summary column](Images\caption-summary\maui-datagrid-template-column.png)
+
+## Group summary
+
+Group summary values are calculated based on the records within each group. The summary information will be displayed at the bottom of each group. You can view the group summary row by expanding the corresponding group header. The data grid allows for the addition of any number of group summary rows.
+
+To add group summary rows in the data grid, you can add the [DataGridSummaryRow]() objects to the [SfDataGrid.GroupSummaryRows]() collection.
+
+### Displaying summary in the row
+
+Summary information can be displayed in the entire row by setting the [DataGridSummaryRow.ShowSummaryInRow]() property to `true` and defining summary columns. The [DataGridSummaryRow.Title]() property needs to be defined based on the [DataGridSummaryRow.Name]() property in order to format the values of the summary columns in a row.
+
+Please refer to the [Formatting Summary]()  section to learn more about how to format the summary.
+
+{% tabs %}
+
+{% highlight xaml %}
+    <sfgrid:SfDataGrid x:Name="dataGrid"
+                       AllowResizingColumn="True"
+                       AllowGroupExpandCollapse="True"
+                       AutoGenerateColumns="True"
+                       ColumnSizer="Star">
+        <sfgrid:SfDataGrid.GroupColumnDescriptions>
+            <sfgrid:GroupColumnDescription ColumnName="Salary" />
+        </sfgrid:SfDataGrid.GroupColumnDescriptions>
+        <sfgrid:SfDataGrid.GroupSummaryRows>
+            <sfgrid:DataGridSummaryRow ShowSummaryInRow="True"
+                                       Title="Total Salary: {Salary} for {customerID} members">
+                <sfgrid:DataGridSummaryRow.SummaryColumns>
+                    <sfgrid:DataGridSummaryColumn Name="Salary"
+                                                  MappingName="Salary"
+                                                  Format="{}{Sum:C0}"
+                                                  SummaryType="DoubleAggregate">
+                    </sfgrid:DataGridSummaryColumn>
+                    <sfgrid:DataGridSummaryColumn Name="customerID"
+                                                  MappingName="CustomerID"
+                                                  Format="{}{Count}"
+                                                  SummaryType="CountAggregate">
+                    </sfgrid:DataGridSummaryColumn>
+                </sfgrid:DataGridSummaryRow.SummaryColumns>
+            </sfgrid:DataGridSummaryRow>
+        </sfgrid:SfDataGrid.GroupSummaryRows>
+    </sfgrid:SfDataGrid>
+{% endhighlight %}
+{% highlight c# %}
+this.dataGrid.GroupSummaryRows.Add(new DataGridSummaryRow()
+{
+    ShowSummaryInRow = true,
+    Title = "Total Salary: {Salary} for {customerID} members",
+    SummaryColumns = new ObservableCollection<ISummaryColumn>()
+    {
+        new DataGridSummaryColumn()
+        {
+            Name="Salary",
+            MappingName="Salary",
+            SummaryType=SummaryType.DoubleAggregate,
+            Format="{Sum}"
+        },
+        new DataGridSummaryColumn()
+        {
+            Name="customerID",
+            MappingName="customerID",
+            Format="{Count}",
+            SummaryType=SummaryType.CountAggregate
+        }
+    }
+});
+{% endhighlight %}
+{% endtabs %}
+
+
+![DataGrid with group summary](Images\group-summary\maui-datagrid-show-summary-in-row.png)
+
+### Displaying summary in the column
+
+The summary information can be displayed in a column by setting the [DataGridSummaryRow.ShowSummaryInRow]() property to `false` and defining summary columns. To calculate the summary based on a column, you need to specify the following properties:
+
+[DataGridSummaryColumn.MappingName](): This property provides the MappingName of the column (the property name of the data object) for which you want to calculate the summary.
+[DataGridSummaryColumn.SummaryType](): This property provides different built-in summary calculation functions for various types.
+[DataGridSummaryColumn.Format](): This property allows you to specify a format string for the summary based on the supported function name in the specified SummaryType.
+
+Please refer to the [Formatting Summary](#formatting-summary) section to learn more about how to format the summary, and the [Aggregate Types](#aggregate-types) section to understand the different Summary Types.
+
+In the following code snippet, a summary is defined for the `Salary` and `CustomerID` columns:
+
+{% tabs %}
+{% highlight xaml %}
+    <sfgrid:SfDataGrid x:Name="dataGrid"
+                       AllowResizingColumn="True"
+                       AutoGenerateColumns="True"
+                       ColumnSizer="Star">
+        <sfgrid:SfDataGrid.GroupSummaryRows>
+            <sfgrid:DataGridSummaryRow ShowSummaryInRow="False">
+                <sfgrid:DataGridSummaryRow.SummaryColumns>
+                    <sfgrid:DataGridSummaryColumn Name="Salary"
+                                                  MappingName="Salary"
+                                                  Format="{}{Sum:C0}"
+                                                  SummaryType="DoubleAggregate">
+                    </sfgrid:DataGridSummaryColumn>
+                </sfgrid:DataGridSummaryRow.SummaryColumns>
+            </sfgrid:DataGridSummaryRow>
+        </sfgrid:SfDataGrid.GroupSummaryRows>
+    </sfgrid:SfDataGrid>
+{% endhighlight %}
+
+{% highlight c# %}
+this.dataGrid.GroupSummaryRows.Add(new DataGridSummaryRow()
+{
+    ShowSummaryInRow = false,
+    SummaryColumns = new ObservableCollection<ISummaryColumn>()
+    {
+        new DataGridSummaryColumn()
+        {
+            Name="Salary",
+            MappingName="Salary",
+            SummaryType=SummaryType.DoubleAggregate,
+            Format="{Sum}"
+        },
+    }
+});
+{% endhighlight %}
+{% endtabs %}
+
+
+![DataGrid with customized summary for group summary cells](Images\group-summary\maui-datagrid-show-summary-in-column.png)
+
+### Group summary template
+
+The data grid allows you to host any view(s) inside a group summary for the entire row or individual columns by loading a template. 
+
+### Displaying template for a row
+
+The template for a group summary row can be customized by using the `SfDataGrid.GroupSummaryTemplate` property.
+
+Refer to the code example below, which demonstrates how to load a label in the group summary template of a group summary row:
+
+{% tabs %}
+{% highlight xaml%}
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <local:GroupSummaryConverter x:Key="SummaryConverter" />
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <sfgrid:SfDataGrid x:Name="dataGrid"
+                       ItemsSource="{Binding OrdersInfo}">
+        <sfgrid:SfDataGrid.GroupSummaryTemplate>
+            <DataTemplate>
+                <StackLayout Orientation="Horizontal">
+                    <Label Text="{Binding Converter={StaticResource SummaryConverter}, ConverterParameter = {x:ReferencedataGrid} }"
+                           FontSize="Default"
+                           VerticalTextAlignment="Center"
+                           HorizontalTextAlignment="Start"
+                           LineBreakMode="NoWrap"
+                           HorizontalOptions="FillAndExpand"
+                           VerticalOptions="FillAndExpand">
+                        <Label.Style>
+                            <Style TargetType="Label">
+                                <Setter Property="FontAttributes"
+                                        Value="Bold, Italic" />
+                            </Style>
+                        </Label.Style>
+                    </Label>
+                </StackLayout>
+            </DataTemplate>
+        </sfgrid:SfDataGrid.GroupSummaryTemplate>
+        <sfgrid:SfDataGrid.GroupSummaryRows>
+            <sfgrid:DataGridSummaryRow Title="salary {Salary}"
+                                       ShowSummaryInRow="True">
+                <sfgrid:DataGridSummaryRow.SummaryColumns>
+                    <sfgrid:DataGridSummaryColumn Name="Salary"
+                                                  MappingName="Salary"
+                                                  Format="{}{Sum:C0}"
+                                                  SummaryType="DoubleAggregate">
+                    </sfgrid:DataGridSummaryColumn>
+                </sfgrid:DataGridSummaryRow.SummaryColumns>
+            </sfgrid:DataGridSummaryRow>
+        </sfgrid:SfDataGrid.GroupSummaryRows>
+    </sfgrid:SfDataGrid>
+{% endhighlight%}
+{% endtabs %}
+
+{% tabs %}
+{% highlight c# %}
+// To write a converter, follow the code example:
+public class GroupSummaryConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        var data = value != null ? value as SummaryRecordEntry : null;
+        if (data != null)
+        {
+            SfDataGrid dataGrid = (SfDataGrid)parameter;
+            var summaryText = SummaryCreator.GetSummaryDisplayText(data,"Salary",dataGrid.View);
+            return "Total Salary:" + " " + summaryText.ToString();
+        }
+        return null;
+    }
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return null;
+    }
+}
+{% endhighlight %}
+{% endtabs %}
+
+![DataGrid with template loaded for entire group summary row](Images\group-summary\maui-datagrid-row-template.png)
+
+N> The `DataTemplateSelector` can also be directly assigned to the `SfDataGrid.GroupSummaryTemplate`.
+
+### Displaying template for a column
+
+The template for a group summary column can be customized by using the `GridSummaryColumn.Template`  property. This allows you to define a custom template according to your requirements.
+
+Please refer to the code example below, which demonstrates how to load a label in the template of a group summary column:
+
+{% tabs %}
+{% highlight xaml%}
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <local:GroupSummaryConverter x:Key="SummaryConverter" />
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <sfgrid:SfDataGrid x:Name="dataGrid"
+                       AllowResizingColumn="True"
+                       AutoGenerateColumns="False"
+                       ColumnSizer="Star">
+        <sfgrid:SfDataGrid.Columns>
+            <sfgrid:DataGridTextColumn MappingName="OrderID" />
+            <sfgrid:DataGridTextColumn MappingName="Salary" />
+            <sfgrid:DataGridTextColumn MappingName="CustomerID" />
+            <sfgrid:DataGridTextColumn MappingName="Country" />
+        </sfgrid:SfDataGrid.Columns>
+        <sfgrid:SfDataGrid.GroupSummaryRows>
+            <sfgrid:DataGridSummaryRow ShowSummaryInRow="False">
+                <sfgrid:DataGridSummaryRow.SummaryColumns>
+                    <sfgrid:DataGridSummaryColumn Name="Salary"
+                                                  MappingName="Salary"
+                                                  Format="{}{Sum:C0}"
+                                                  SummaryType="DoubleAggregate">
+                        <sfgrid:DataGridSummaryColumn.Template>
+                            <DataTemplate>
+                                <StackLayout Orientation="Horizontal"
+                                             BackgroundColor="Gray">
+                                    <Label Text="{Binding Converter={StaticResource SummaryConverter}, ConverterParameter {x:ReferencedataGrid} }"
+                                           VerticalOptions="CenterAndExpand"
+                                           TextColor="White"
+                                           FontSize="Medium"
+                                           VerticalTextAlignment="Center"
+                                           HorizontalTextAlignment="Start"
+                                           LineBreakMode="NoWrap"
+                                           HorizontalOptions="FillAndExpand">
+                                        <Label.Style>
+                                            <Style TargetType="Label">
+                                                <Setter Property="FontAttributes"
+                                                        Value="Italic" />
+                                            </Style>
+                                        </Label.Style>
+                                    </Label>
+                                </StackLayout>
+                            </DataTemplate>
+                        </sfgrid:DataGridSummaryColumn.Template>
+                    </sfgrid:DataGridSummaryColumn>
+                </sfgrid:DataGridSummaryRow.SummaryColumns>
+            </sfgrid:DataGridSummaryRow>
+        </sfgrid:SfDataGrid.GroupSummaryRows>
+    </sfgrid:SfDataGrid>
+{% endhighlight%}
+{% endtabs %}
+
+{% tabs %}
+{% highlight c# %}
+// To write a converter, follow the code example:
+public class GroupSummaryConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        var data = value != null ? value as SummaryRecordEntry : null;
+        if (data != null)
+        {
+            SfDataGrid dataGrid = (SfDataGrid)parameter;
+            var summaryText = SummaryCreator.GetSummaryDisplayText(data,"Salary",dataGrid.View);
+            return summaryText.ToString();
+        }
+        return null;
+    }
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return null;
+    }
+}
+{% endhighlight %}
+{% endtabs %}
+
+![DataGrid with template loaded for individual group summary cell](Images\group-summary\maui-datagrid-column-template.png)
+
+
 ## Table summaries
 
 The data grid provides built-in support for table summaries. The table summary value is calculated based on all records in the control.
@@ -30,34 +635,35 @@ You can add table summary row in the data grid by adding the [DataGridTableSumma
 
 The following screenshot illustrates table summary rows in the data grid:
 
-![DataGrid with table summary](Images\Table-Summary\Summary.png)
+![DataGrid with table summary](Images\table-summary\maui-datagrid-table-summary-position.png)
 
 {% tabs %}
 {% highlight xaml%}
-<sfGrid:SfDataGrid.TableSummaryRows>
-    <sfGrid:DataGridTableSummaryRow Title="Total Salary :{TotalSalary} for {ProductCount} members"
-                                Position="Top"
-                                ShowSummaryInRow="True">
-        <sfGrid:DataGridTableSummaryRow.SummaryColumns>
-            <sfGrid:DataGridSummaryColumn Name="TotalSalary"
-                                      Format="{}{Sum:C0}"
-                                      MappingName="Salary"
-                                      SummaryType="DoubleAggregate" />
-            <sfGrid:DataGridSummaryColumn Name="ProductCount"
-                                      Format="{}{Count}"
-                                      MappingName="Salary"
-                                      SummaryType="CountAggregate" />
-            </sfGrid:DataGridTableSummaryRow.SummaryColumns>
-        </sfGrid:DataGridTableSummaryRow>
-    <sfGrid:DataGridTableSummaryRow Position="Top" ShowSummaryInRow="False">
-        <sfGrid:DataGridTableSummaryRow.SummaryColumns>
-            <sfGrid:DataGridSummaryColumn Name="TotalSalary"
-                                      Format="{}{Sum:C0}"
-                                      MappingName="Salary"
-                                      SummaryType="DoubleAggregate" />
-            </sfGrid:DataGridTableSummaryRow.SummaryColumns>
-        </sfGrid:DataGridTableSummaryRow>
-</sfGrid:SfDataGrid.TableSummaryRows>
+                <sfGrid:SfDataGrid.TableSummaryRows>
+                <sfGrid:DataGridTableSummaryRow Title="Total Salary :{TotalSalary} for {ProductCount} members"
+                                                Position="Top"
+                                                ShowSummaryInRow="True">
+                    <sfGrid:DataGridTableSummaryRow.SummaryColumns>
+                        <sfGrid:DataGridSummaryColumn Name="TotalSalary"
+                                                      Format="{}{Sum:C0}"
+                                                      MappingName="Salary"
+                                                      SummaryType="DoubleAggregate" />
+                        <sfGrid:DataGridSummaryColumn Name="ProductCount"
+                                                      Format="{}{Count}"
+                                                      MappingName="Salary"
+                                                      SummaryType="CountAggregate" />
+                    </sfGrid:DataGridTableSummaryRow.SummaryColumns>
+                </sfGrid:DataGridTableSummaryRow>
+                <sfGrid:DataGridTableSummaryRow Position="Top"
+                                                ShowSummaryInRow="False">
+                    <sfGrid:DataGridTableSummaryRow.SummaryColumns>
+                        <sfGrid:DataGridSummaryColumn Name="TotalSalary"
+                                                      Format="{}{Sum:C0}"
+                                                      MappingName="Salary"
+                                                      SummaryType="DoubleAggregate" />
+                    </sfGrid:DataGridTableSummaryRow.SummaryColumns>
+                </sfGrid:DataGridTableSummaryRow>
+            </sfGrid:SfDataGrid.TableSummaryRows>
 {% endhighlight %}
 
 {% highlight c#%}
@@ -95,7 +701,8 @@ sfGrid.TableSummaryRows.Add(summaryRow2);
 {% endhighlight %}
 {% endtabs %}
 
-![DataGrid with table summary](Images\Table-Summary\TableSummary.png)
+
+![DataGrid with table summary](Images\table-summary\maui-datagrid-table-summary.png)
 
 ### Displaying summary in a row
 
@@ -104,20 +711,20 @@ Display summary information in a row by setting the [DataGridTableSummaryRow.Sho
 {% tabs %}
 {% highlight xaml%}
 <sfGrid:SfDataGrid.TableSummaryRows>
-    <sfGrid:DataGridTableSummaryRow Title="Total Salary :{TotalSalary} for {ProductCount} members"
-                                ShowSummaryInRow="True">
-        <sfGrid:DataGridTableSummaryRow.SummaryColumns>
-            <sfGrid:DataGridSummaryColumn Name="TotalSalary"
-                                      Format="{}{Sum:C0}"
-                                      MappingName="Salary"
-                                      SummaryType="DoubleAggregate" />
-            <sfGrid:DataGridSummaryColumn Name="ProductCount"
-                                      Format="{}{Count}"
-                                      MappingName="Salary"
-                                      SummaryType="CountAggregate" />
-            </sfGrid:DataGridTableSummaryRow.SummaryColumns>
-        </sfGrid:DataGridTableSummaryRow>
-</sfGrid:SfDataGrid.TableSummaryRows>
+                <sfGrid:DataGridTableSummaryRow Title="Total Salary :{TotalSalary} for {ProductCount} members"
+                                                ShowSummaryInRow="True">
+                    <sfGrid:DataGridTableSummaryRow.SummaryColumns>
+                        <sfGrid:DataGridSummaryColumn Name="TotalSalary"
+                                                      Format="{}{Sum:C0}"
+                                                      MappingName="Salary"
+                                                      SummaryType="DoubleAggregate" />
+                        <sfGrid:DataGridSummaryColumn Name="ProductCount"
+                                                      Format="{}{Count}"
+                                                      MappingName="Salary"
+                                                      SummaryType="CountAggregate" />
+                    </sfGrid:DataGridTableSummaryRow.SummaryColumns>
+                </sfGrid:DataGridTableSummaryRow>
+            </sfGrid:SfDataGrid.TableSummaryRows>
 {% endhighlight %}
 
 {% highlight c#%}
@@ -144,7 +751,7 @@ sfGrid.TableSummaryRows.Add(summaryRow);
 
 The following screenshot shows the table summary row if `ShowSummaryInRow` is `true`:
 
-![DataGrid with customized table summary for entire row](Images\Table-Summary\ShowSummaryInRow.png)
+![DataGrid with customized table summary for entire row](Images\table-summary\maui-datagrid-show-summary-in-row.png)
 
 ### Displaying summary in a column
 
@@ -170,16 +777,17 @@ In the following code snippet, summary is defined for `Salary` column:
 
 {% tabs %}
 {% highlight xaml%}
-<sfGrid:SfDataGrid.TableSummaryRows>
-    <sfGrid:DataGridTableSummaryRow Name="TableSummary" ShowSummaryInRow="False">
-        <sfGrid:DataGridTableSummaryRow.SummaryColumns>
-            <sfGrid:DataGridSummaryColumn Name="TableSummary"
-                                      Format="{}{Sum:C0}"
-                                      MappingName="Salary"
-                                      SummaryType="DoubleAggregate" />
-        </sfGrid:DataGridTableSummaryRow.SummaryColumns>
-    </sfGrid:DataGridTableSummaryRow>
-</sfGrid:SfDataGrid.TableSummaryRows>
+            <sfGrid:SfDataGrid.TableSummaryRows>
+                <sfGrid:DataGridTableSummaryRow Name="TableSummary"
+                                                ShowSummaryInRow="False">
+                    <sfGrid:DataGridTableSummaryRow.SummaryColumns>
+                        <sfGrid:DataGridSummaryColumn Name="TableSummary"
+                                                      Format="{}{Sum:C0}"
+                                                      MappingName="Salary"
+                                                      SummaryType="DoubleAggregate" />
+                    </sfGrid:DataGridTableSummaryRow.SummaryColumns>
+                </sfGrid:DataGridTableSummaryRow>
+            </sfGrid:SfDataGrid.TableSummaryRows>
 {% endhighlight %}
 
 {% highlight c#%}
@@ -198,7 +806,7 @@ sfGrid.TableSummaryRows.Add(summaryRow);
 
 The following screenshot shows the table summary row if `ShowSummaryInRow` is `false`.
 
-![DataGrid with customized table summary for individual cells](Images\Table-Summary\ShowSummaryInColumn.png)
+![DataGrid with customized table summary for individual cells](Images\table-summary\maui-datagrid-show-summary-in-column.png)
 
 ### Positioning TableSummaryRows
 
@@ -206,31 +814,31 @@ The data grid add table summary rows either at top or bottom positions using the
 
 {% tabs %}
 {% highlight xaml%}
-<sfGrid:SfDataGrid.TableSummaryRows>
-    <sfGrid:DataGridTableSummaryRow Position="Top"
-                                ShowSummaryInRow="False">
-        <sfGrid:DataGridTableSummaryRow.SummaryColumns>
-            <sfGrid:DataGridSummaryColumn Name="TotalSalary"
-                                      Format="{}{Sum:C0}"
-                                      MappingName="Salary"
-                                      SummaryType="DoubleAggregate" />
-            </sfGrid:DataGridTableSummaryRow.SummaryColumns>
-        </sfGrid:DataGridTableSummaryRow>
-    <sfGrid:DataGridTableSummaryRow Position="Bottom"
-                                ShowSummaryInRow="True"
-                                Title="Total Salary :{TotalSalary} for {ProductCount} members">
-        <sfGrid:DataGridTableSummaryRow.SummaryColumns>
-            <sfGrid:DataGridSummaryColumn Name="TotalSalary"
-                                      Format="{}{Sum:C0}"
-                                      MappingName="Salary"
-                                      SummaryType="DoubleAggregate" />
-            <sfGrid:DataGridSummaryColumn Name="ProductCount"
-                                      Format="{}{Count}"
-                                      MappingName="Salary"
-                                      SummaryType="CountAggregate" />
-        </sfGrid:DataGridTableSummaryRow.SummaryColumns>
-    </sfGrid:DataGridTableSummaryRow>
-</sfGrid:SfDataGrid.TableSummaryRows>
+            <sfGrid:SfDataGrid.TableSummaryRows>
+                <sfGrid:DataGridTableSummaryRow Position="Top"
+                                                ShowSummaryInRow="False">
+                    <sfGrid:DataGridTableSummaryRow.SummaryColumns>
+                        <sfGrid:DataGridSummaryColumn Name="TotalSalary"
+                                                      Format="{}{Sum:C0}"
+                                                      MappingName="Salary"
+                                                      SummaryType="DoubleAggregate" />
+                    </sfGrid:DataGridTableSummaryRow.SummaryColumns>
+                </sfGrid:DataGridTableSummaryRow>
+                <sfGrid:DataGridTableSummaryRow Position="Bottom"
+                                                ShowSummaryInRow="True"
+                                                Title="Total Salary :{TotalSalary} for {ProductCount} members">
+                    <sfGrid:DataGridTableSummaryRow.SummaryColumns>
+                        <sfGrid:DataGridSummaryColumn Name="TotalSalary"
+                                                      Format="{}{Sum:C0}"
+                                                      MappingName="Salary"
+                                                      SummaryType="DoubleAggregate" />
+                        <sfGrid:DataGridSummaryColumn Name="ProductCount"
+                                                      Format="{}{Count}"
+                                                      MappingName="Salary"
+                                                      SummaryType="CountAggregate" />
+                    </sfGrid:DataGridTableSummaryRow.SummaryColumns>
+                </sfGrid:DataGridTableSummaryRow>
+            </sfGrid:SfDataGrid.TableSummaryRows>
 {% endhighlight %}
 
 {% highlight c#%}
@@ -270,7 +878,7 @@ sfGrid.TableSummaryRows.Add(bottomSummaryRow);
 
 The below screenshot illustrates the positioning of table summary rows in SfDataGrid.
 
-![Customizing table summary row position in a DataGrid](Images\Table-Summary\Summary.png)
+![Customizing table summary row position in a DataGrid](Images\table-summary\maui-datagrid-table-summary-position.png)
 
 ## Table summary template
 
@@ -284,67 +892,66 @@ Refer the below code example in which a label is loaded in the table summary tem
 
 {% tabs %}
 {% highlight xaml %}
-
- <ContentPage.Resources>
-        <ResourceDictionary>
-            <local:TableSummaryConverter x:Key="SummaryConverter" />
-        </ResourceDictionary>
-    </ContentPage.Resources>
-    <StackLayout>
-        <sfgrid:SfDataGrid x:Name="dataGrid"
-                           ItemsSource="{Binding OrdersInfo}"
-                           AutoGenerateColumns="False"
-                           AllowEditing="True"
-                           NavigationMode="Cell"
-                           SelectionMode="Single"
-                           ColumnSizer="Star">
-            <sfgrid:SfDataGrid.Columns>
-                <sfgrid:GridNumericColumn MappingName="OrderID" />
-                <sfgrid:GridTextColumn MappingName="EmployeeID" />
-                <sfgrid:GridTextColumn MappingName="FirstName"  />
-                <sfgrid:GridTextColumn MappingName="LastName"  />
-            </sfgrid:SfDataGrid.Columns>
-            <sfgrid:SfDataGrid.TableSummaryTemplate>
-                <DataTemplate>
-                        <StackLayout Orientation="Horizontal" BackgroundColor="Gray">
-                            <Label Text="{Binding Converter={StaticResource SummaryConverter}, ConverterParameter = {x:Reference dataGrid} }"
-                                   TextColor="White"
-                                   FontSize="Large"
-                                   VerticalTextAlignment="Center"
-                                   HorizontalTextAlignment="Start"
-                                   LineBreakMode="NoWrap"
-                                   HorizontalOptions="FillAndExpand"
-                                   VerticalOptions="FillAndExpand">
-                                <Label.Style>
-                                    <Style TargetType="Label">
-                                        <Setter Property="FontAttributes" Value="Italic" />
-                                    </Style>
-                                </Label.Style>
-                            </Label>
-                        </StackLayout>
-                </DataTemplate>
-            </sfgrid:SfDataGrid.TableSummaryTemplate>
-            <sfgrid:SfDataGrid.TableSummaryRows>
-                <sfgrid:DataGridTableSummaryRow Title="Total Salary :{TotalSalary} for {ProductCount} members"
-                                            Position="Bottom"
-                                            ShowSummaryInRow="True">
-                    <sfgrid:DataGridTableSummaryRow.SummaryColumns>
-                        <sfgrid:DataGridSummaryColumn Name="TotalSalary"
-                                                  Format="{}{Sum:C0}"
-                                                  MappingName="Salary"
-                                                  SummaryType="DoubleAggregate" />
-                    </sfgrid:DataGridTableSummaryRow.SummaryColumns>
-                </sfgrid:DataGridTableSummaryRow>
-            </sfgrid:SfDataGrid.TableSummaryRows>
-        </sfgrid:SfDataGrid>
-    </StackLayout>
-
+            <ContentPage.Resources>
+                <ResourceDictionary>
+                    <local:TableSummaryConverter x:Key="SummaryConverter" />
+                </ResourceDictionary>
+            </ContentPage.Resources>
+            <StackLayout>
+                <sfgrid:SfDataGrid x:Name="dataGrid"
+                                   ItemsSource="{Binding OrdersInfo}"
+                                   AutoGenerateColumns="False"
+                                   AllowEditing="True"
+                                   NavigationMode="Cell"
+                                   SelectionMode="Single"
+                                   ColumnSizer="Star">
+                    <sfgrid:SfDataGrid.Columns>
+                        <sfgrid:GridNumericColumn MappingName="OrderID" />
+                        <sfgrid:GridTextColumn MappingName="EmployeeID" />
+                        <sfgrid:GridTextColumn MappingName="FirstName" />
+                        <sfgrid:GridTextColumn MappingName="LastName" />
+                    </sfgrid:SfDataGrid.Columns>
+                    <sfgrid:SfDataGrid.TableSummaryTemplate>
+                        <DataTemplate>
+                            <StackLayout Orientation="Horizontal"
+                                         BackgroundColor="Gray">
+                                <Label Text="{Binding Converter={StaticResource SummaryConverter}, ConverterParameter = {x:Reference dataGrid} }"
+                                       TextColor="White"
+                                       FontSize="Large"
+                                       VerticalTextAlignment="Center"
+                                       HorizontalTextAlignment="Start"
+                                       LineBreakMode="NoWrap"
+                                       HorizontalOptions="FillAndExpand"
+                                       VerticalOptions="FillAndExpand">
+                                    <Label.Style>
+                                        <Style TargetType="Label">
+                                            <Setter Property="FontAttributes"
+                                                    Value="Italic" />
+                                        </Style>
+                                    </Label.Style>
+                                </Label>
+                            </StackLayout>
+                        </DataTemplate>
+                    </sfgrid:SfDataGrid.TableSummaryTemplate>
+                    <sfgrid:SfDataGrid.TableSummaryRows>
+                        <sfgrid:DataGridTableSummaryRow Title="Total Salary :{TotalSalary} for {ProductCount} members"
+                                                        Position="Bottom"
+                                                        ShowSummaryInRow="True">
+                            <sfgrid:DataGridTableSummaryRow.SummaryColumns>
+                                <sfgrid:DataGridSummaryColumn Name="TotalSalary"
+                                                              Format="{}{Sum:C0}"
+                                                              MappingName="Salary"
+                                                              SummaryType="DoubleAggregate" />
+                            </sfgrid:DataGridTableSummaryRow.SummaryColumns>
+                        </sfgrid:DataGridTableSummaryRow>
+                    </sfgrid:SfDataGrid.TableSummaryRows>
+                </sfgrid:SfDataGrid>
+            </StackLayout>
 {% endhighlight %}
 {% endtabs %}
 
 {% tabs %}
 {% highlight c# %}
-
  public class TableSummaryConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
@@ -365,11 +972,10 @@ Refer the below code example in which a label is loaded in the table summary tem
         return null;
     }
 }
-
 {% endhighlight %}
 {% endtabs %}
 
-![Table summary template in a row](Images\Table-Summary\TemplateRow.png)
+![Table summary template in a row](Images\table-summary\maui-datagrid-template-row.png)
 
 ### Displaying template for a column
 
@@ -379,95 +985,93 @@ Refer the below code example in which a label is loaded in the template of table
 
 {% tabs %}
 {% highlight xaml%}
-
-<ContentPage.Resources>
-        <ResourceDictionary>
-            <local:TableSummaryConverter x:Key="SummaryConverter" />
-        </ResourceDictionary>
-    </ContentPage.Resources>
-    <StackLayout>
-        <sfgrid:SfDataGrid x:Name="dataGrid"
-                           ItemsSource="{Binding OrdersInfo}"
-                           AutoGenerateColumns="False"
-                           AllowEditing="True"
-                           NavigationMode="Cell"
-                           SelectionMode="Single"
-                           ColumnSizer="Star">
-            <sfgrid:SfDataGrid.Columns>
-                <sfgrid:GridNumericColumn MappingName="OrderID" />
-                <sfgrid:GridTextColumn MappingName="EmployeeID" />
-                <sfgrid:GridTextColumn MappingName="FirstName" />
-                <sfgrid:GridTextColumn MappingName="LastName" />
-            </sfgrid:SfDataGrid.Columns>
-            <sfgrid:SfDataGrid.TableSummaryRows>
-                <sfgrid:DataGridTableSummaryRow Title="Total Salary :{TotalSalary} for {ProductCount} members"
-                                            Position="Bottom"
-                                            ShowSummaryInRow="False">
-                        <sfgrid:DataGridTableSummaryRow.SummaryColumns>
-                            <sfgrid:DataGridSummaryColumn Name="TotalSalary"
-                                                      Format="{}{Sum:C0}"
-                                                      MappingName="Salary"
-                                                      SummaryType="DoubleAggregate" >
-                                <sfgrid:DataGridSummaryColumn.Template>
-                                 <DataTemplate>
-                                    <StackLayout Orientation="Horizontal" BackgroundColor="Gray">
-                                        <Label Text="{Binding Converter={StaticResource SummaryConverter}, ConverterParameter = {x:Reference dataGrid} }"
-                                               TextColor="White"
-                                               FontSize="Medium"
-                                               VerticalTextAlignment="Center"
-                                               HorizontalTextAlignment="Start"
-                                               LineBreakMode="NoWrap"
-                                               HorizontalOptions="FillAndExpand"
-                                               VerticalOptions="FillAndExpand">
-                                            <Label.Style>
-                                                <Style TargetType="Label">
-                                                    <Setter Property="FontAttributes" Value="Italic" />
-                                                </Style>
-                                            </Label.Style>
-                                        </Label>
-                                    </StackLayout>
-                                 </DataTemplate>
-                                </sfgrid:DataGridSummaryColumn.Template>
-                            </sfgrid:DataGridSummaryColumn>
-                        </sfgrid:DataGridTableSummaryRow.SummaryColumns>
-                    </sfgrid:DataGridTableSummaryRow>
-            </sfgrid:SfDataGrid.TableSummaryRows>            
-        </sfgrid:SfDataGrid>
-    </StackLayout>
-
+            <ContentPage.Resources>
+                <ResourceDictionary>
+                    <local:TableSummaryConverter x:Key="SummaryConverter" />
+                </ResourceDictionary>
+            </ContentPage.Resources>
+            <StackLayout>
+                <sfgrid:SfDataGrid x:Name="dataGrid"
+                                   ItemsSource="{Binding OrdersInfo}"
+                                   AutoGenerateColumns="False"
+                                   AllowEditing="True"
+                                   NavigationMode="Cell"
+                                   SelectionMode="Single"
+                                   ColumnSizer="Star">
+                    <sfgrid:SfDataGrid.Columns>
+                        <sfgrid:GridNumericColumn MappingName="OrderID" />
+                        <sfgrid:GridTextColumn MappingName="EmployeeID" />
+                        <sfgrid:GridTextColumn MappingName="FirstName" />
+                        <sfgrid:GridTextColumn MappingName="LastName" />
+                    </sfgrid:SfDataGrid.Columns>
+                    <sfgrid:SfDataGrid.TableSummaryRows>
+                        <sfgrid:DataGridTableSummaryRow Title="Total Salary :{TotalSalary} for {ProductCount} members"
+                                                        Position="Bottom"
+                                                        ShowSummaryInRow="False">
+                            <sfgrid:DataGridTableSummaryRow.SummaryColumns>
+                                <sfgrid:DataGridSummaryColumn Name="TotalSalary"
+                                                              Format="{}{Sum:C0}"
+                                                              MappingName="Salary"
+                                                              SummaryType="DoubleAggregate">
+                                    <sfgrid:DataGridSummaryColumn.Template>
+                                        <DataTemplate>
+                                            <StackLayout Orientation="Horizontal"
+                                                         BackgroundColor="Gray">
+                                                <Label Text="{Binding Converter={StaticResource SummaryConverter}, ConverterParameter = {x:Reference dataGrid} }"
+                                                       TextColor="White"
+                                                       FontSize="Medium"
+                                                       VerticalTextAlignment="Center"
+                                                       HorizontalTextAlignment="Start"
+                                                       LineBreakMode="NoWrap"
+                                                       HorizontalOptions="FillAndExpand"
+                                                       VerticalOptions="FillAndExpand">
+                                                    <Label.Style>
+                                                        <Style TargetType="Label">
+                                                            <Setter Property="FontAttributes"
+                                                                    Value="Italic" />
+                                                        </Style>
+                                                    </Label.Style>
+                                                </Label>
+                                            </StackLayout>
+                                        </DataTemplate>
+                                    </sfgrid:DataGridSummaryColumn.Template>
+                                </sfgrid:DataGridSummaryColumn>
+                            </sfgrid:DataGridTableSummaryRow.SummaryColumns>
+                        </sfgrid:DataGridTableSummaryRow>
+                    </sfgrid:SfDataGrid.TableSummaryRows>
+                </sfgrid:SfDataGrid>
+            </StackLayout>
 {% endhighlight%}
 {% endtabs %}
 
 {% tabs %}
 {% highlight c# %}
-
 // To write a converter, follow the code example:
-
-  public class TableSummaryConverter : IValueConverter
+public class TableSummaryConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        var data = value != null ? value as SummaryRecordEntry : null;
+        if (data != null)
         {
-            var data = value != null ? value as SummaryRecordEntry : null;
-            if (data != null)
-            {
-                SfDataGrid dataGrid = (SfDataGrid)parameter;
-                var summaryText = SummaryCreator.GetSummaryDisplayText(data, "Salary", dataGrid.View);
+            SfDataGrid dataGrid = (SfDataGrid)parameter;
+            var summaryText = SummaryCreator.GetSummaryDisplayText(data, "Salary", dataGrid.View);
 
-                return summaryText.ToString();
-            }
-
-            return null;
+            return summaryText.ToString();
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            return null;
-        }    
+        return null;
     }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return null;
+    }    
+}
 {% endhighlight %}
 {% endtabs %}
 
-![Table summary template in a column](Images\Table-Summary\TemplateColumn.png)
+![Table summary template in a column](Images\table-summary\maui-datagrid-template-column.png)
 
 N> The `DataTemplateSelector` can also be directly assigned to the `SfDataGrid.TableSummaryTemplate`.
 
@@ -483,16 +1087,16 @@ In the following code snippet `Salary` column summary is formatted using `C0` fo
 
 {% tabs %}
 {% highlight xaml%}
-<sfGrid:SfDataGrid.TableSummaryRows>
-    <sfGrid:DataGridTableSummaryRow ShowSummaryInRow="False">
-        <sfGrid:DataGridTableSummaryRow.SummaryColumns>
-            <sfGrid:DataGridSummaryColumn Name="TableSummary"
-                                      Format="{}{Sum:C0}"
-                                      MappingName="Salary"
-                                      SummaryType="DoubleAggregate" />
-        </sfGrid:DataGridTableSummaryRow.SummaryColumns>
-    </sfGrid:DataGridTableSummaryRow>
-</sfGrid:SfDataGrid.TableSummaryRows>
+            <sfGrid:SfDataGrid.TableSummaryRows>
+                <sfGrid:DataGridTableSummaryRow ShowSummaryInRow="False">
+                    <sfGrid:DataGridTableSummaryRow.SummaryColumns>
+                        <sfGrid:DataGridSummaryColumn Name="TableSummary"
+                                                      Format="{}{Sum:C0}"
+                                                      MappingName="Salary"
+                                                      SummaryType="DoubleAggregate" />
+                    </sfGrid:DataGridTableSummaryRow.SummaryColumns>
+                </sfGrid:DataGridTableSummaryRow>
+            </sfGrid:SfDataGrid.TableSummaryRows>
 {% endhighlight %}
 
 {% highlight c#%}
@@ -509,7 +1113,7 @@ sfGrid.TableSummaryRows= summaryRow;
 {% endhighlight %}
 {% endtabs %}
 
-![Formatting summary value in a DataGrid](Images\Table-Summary\ShowSummaryInColumn.png)
+![Formatting summary value in a DataGrid](Images\table-summary\maui-datagrid-show-summary-in-column.png)
 
 
 ### Displaying additional content in summary
@@ -520,16 +1124,16 @@ In the following code snippet `Total:` text is appended before summary value:
 
 {% tabs %}
 {% highlight xaml%}
-<sfGrid:SfDataGrid.TableSummaryRows>
-    <sfGrid:DataGridTableSummaryRow ShowSummaryInRow="False">
-        <sfGrid:DataGridTableSummaryRow.SummaryColumns>
-            <sfGrid:DataGridSummaryColumn Name="TableSummary"
-                                      Format="Total: {Sum:C0}"
-                                      MappingName="Salary"
-                                      SummaryType="DoubleAggregate" />
-        </sfGrid:DataGridTableSummaryRow.SummaryColumns>
-    </sfGrid:DataGridTableSummaryRow>
-</sfGrid:SfDataGrid.TableSummaryRows>
+            <sfGrid:SfDataGrid.TableSummaryRows>
+                <sfGrid:DataGridTableSummaryRow ShowSummaryInRow="False">
+                    <sfGrid:DataGridTableSummaryRow.SummaryColumns>
+                        <sfGrid:DataGridSummaryColumn Name="TableSummary"
+                                                      Format="Total: {Sum:C0}"
+                                                      MappingName="Salary"
+                                                      SummaryType="DoubleAggregate" />
+                    </sfGrid:DataGridTableSummaryRow.SummaryColumns>
+                </sfGrid:DataGridTableSummaryRow>
+            </sfGrid:SfDataGrid.TableSummaryRows>
 {% endhighlight %}
 
 {% highlight c#%}
@@ -546,7 +1150,7 @@ sfGrid.TableSummaryRows= summaryRow;
 {% endhighlight %}
 {% endtabs %}
 
-![Displaying additional content in summary in a DataGrid](Images\Table-Summary\AdditionalContent.png)
+![Displaying additional content in summary in a DataGrid](Images\table-summary\maui-datagrid-additional-content.png)
 
 ## Aggregate types
 
@@ -662,17 +1266,18 @@ Assign the custom aggregate to `DataGridSummaryColumn.CustomAggregate` property 
 
 {% tabs %}
 {% highlight xaml%}
-<sfGrid:SfDataGrid.TableSummaryRows>
-    <sfGrid:DataGridTableSummaryRow Title="Standard Deviation:{TableSummary}" ShowSummaryInRow = "True">                                                     
-        <sfGrid:DataGridTableSummaryRow.SummaryColumns>
-            <sfGrid:DataGridSummaryColumn Name="TableSummary"
-                                      CustomAggregate="{StaticResource customAggregate}"
-                                      Format="{}{StdDev}"
-                                      MappingName="OrderID"
-                                      SummaryType="Custom" />
-        </sfGrid:DataGridTableSummaryRow.SummaryColumns>
-    </sfGrid:DataGridTableSummaryRow>
-</sfGrid:SfDataGrid.TableSummaryRows>
+            <sfGrid:SfDataGrid.TableSummaryRows>
+                <sfGrid:DataGridTableSummaryRow Title="Standard Deviation:{TableSummary}"
+                                                ShowSummaryInRow="True">
+                    <sfGrid:DataGridTableSummaryRow.SummaryColumns>
+                        <sfGrid:DataGridSummaryColumn Name="TableSummary"
+                                                      CustomAggregate="{StaticResource customAggregate}"
+                                                      Format="{}{StdDev}"
+                                                      MappingName="OrderID"
+                                                      SummaryType="Custom" />
+                    </sfGrid:DataGridTableSummaryRow.SummaryColumns>
+                </sfGrid:DataGridTableSummaryRow>
+            </sfGrid:SfDataGrid.TableSummaryRows>
 {% endhighlight %}
 
 {% highlight c#%}
@@ -691,7 +1296,7 @@ dataGrid.TableSummaryRows = summaryRow;
 {% endhighlight %}
 {% endtabs %}
 
-![DataGrid with custom aggregate](Images\Table-Summary\CustomAggregate.png)
+![DataGrid with custom aggregate](Images\table-summary\maui-datagrid-custom-aggregate.png)
 
 N> The above custom summaries section is explained using `TableSummary`.
 
@@ -711,7 +1316,7 @@ Each summary has a specific key using which the custom summary renderer can be r
 
 <tr>
 <td>Table summary</td>
-<td><a href="">DataDataGridTableSummaryCellRenderer</a> </td>
+<td><a href=</a> </td>
 <td>TableSummary</td>
 </tr>
 
@@ -727,22 +1332,20 @@ To customize the table summary, follow the code example:
 
 {% tabs %}
 {% highlight c#%}
-
 // To remove default summary and Add custom summary.
-
 public class Summary : ContentPage
 {
     public Summary()
     {
         InitializeComponent();
         dataGrid.CellRenderers.Remove("TableSummary");
-        dataGrid.CellRenderers.Add("TableSummary", new DataDataGridTableSummaryCellRendererExt());
+        dataGrid.CellRenderers.Add("TableSummary", new DataGridTableSummaryCellRendererExt());
     }
 }
 
-public class DataDataGridTableSummaryCellRendererExt : DataDataGridTableSummaryCellRenderer
+public class DataGridTableSummaryCellRendererExt : DataGridTableSummaryCellRenderer
 {
-    public DataDataGridTableSummaryCellRendererExt()
+    public DataGridTableSummaryCellRendererExt()
     {
     }
 
@@ -750,9 +1353,9 @@ public class DataDataGridTableSummaryCellRendererExt : DataDataGridTableSummaryC
     {
         base.OnInitializeDisplayView(dataColumn, view);
         view.HorizontalTextAlignment = TextAlignment.Start;
-        view.BackgroundColor = Color.DarkCyan;
+        view.BackgroundColor = Colors.DarkCyan;
         view.FontSize = 16;
-        view.TextColor = Color.White;
+        view.TextColor = Colors.White;
 
     }
 }
@@ -761,4 +1364,4 @@ public class DataDataGridTableSummaryCellRendererExt : DataDataGridTableSummaryC
 
 The following screenshot shows the final outcome upon execution of the above code.
 
-![Customize table summary using custom cell renderer](Images\Table-Summary\CustomizingTableSummary.png)
+![Customize table summary using custom cell renderer](Images\table-summary\maui-datagrid-customizing-table-summary.png)


### PR DESCRIPTION
**Description**
we already have a UG documentation for table summary rows, we updated the caption and group summary rows in it.