### PR TITLE
847686- [Hotfix]Update user guide APIs reference links in .Net Maui Charts.

### DIFF
--- a/MAUI/Cartesian-Charts/Area.md
+++ b/MAUI/Cartesian-Charts/Area.md
@@ -154,7 +154,7 @@ this.Content= chart;
 
 In order to change the series markers appearance, create an instance of the [MarkerSettings](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.AreaSeries.html#Syncfusion_Maui_Charts_AreaSeries_MarkerSettings) property. The following properties are used to customize marker appearance.
 
-* [Type](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_Type), of type `ShapeType`, describes the shape of the series marker. The default value of this property is [ShapeType.Circle]().
+* [Type](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_Type), of type `ShapeType`, describes the shape of the series marker. The default value of this property is [ShapeType.Circle](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ShapeType.html#Syncfusion_Maui_Charts_ShapeType_Circle).
 * [Stroke](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_Stroke), of type `Brush`, indicates the brush used to paint the marker border.
 * [StrokeWidth](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_StrokeWidth), of type `double`, indicates the width of the marker border.
 * [Fill](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_Fill), of type `Brush`, indicates the color of the marker.

--- a/MAUI/Cartesian-Charts/Axis/Axislabels.md
+++ b/MAUI/Cartesian-Charts/Axis/Axislabels.md
@@ -47,21 +47,21 @@ chart.XAxes.Add(primaryAxis);
 
 The [LabelStyle](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartAxis.html#Syncfusion_Maui_Charts_ChartAxis_LabelStyle) property of axis provides options to customize the font-family, font-size, font-attributes and text color of axis labels. The axis labels can be customized using following properties:
 
-* `Background` - Gets or sets the background color of the labels.
-* `CornerRadius` - Gets or sets a value that defines the rounded corners for labels.
-* `FontAttributes` - Gets or sets the font style for the label.
-* `FontFamily` - Gets or sets the font family name for the label.
-* `FontSize` - Gets or sets the font size for the label.
-* `Margin` - Gets or sets the margin of the label to customize the appearance of label. 
-* `Stroke` - Gets or sets the border stroke color of the labels.
-* `StrokeWidth` - Gets or sets the border thickness of the label.
-* `TextColor` - Gets or sets the color for the text of the label.
-* `LabelFormat` - Gets or sets the label format. This property is used to set numeric or date-time format to the chart axis label.
-* `LabelAlignment` - Gets or sets the axis label at start, end, and center positions.
+* [Background](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_Background) - Gets or sets the background color of the labels.
+* [CornerRadius](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_CornerRadius) - Gets or sets a value that defines the rounded corners for labels.
+* [FontAttributes](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_FontAttributes) - Gets or sets the font style for the label.
+* [FontFamily](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_FontFamily) - Gets or sets the font family name for the label.
+* [FontSize](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_FontSize) - Gets or sets the font size for the label.
+* [Margin](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_Margin) - Gets or sets the margin of the label to customize the appearance of label. 
+* [Stroke](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_Stroke) - Gets or sets the border stroke color of the labels.
+* [StrokeWidth](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_StrokeWidth) - Gets or sets the border thickness of the label.
+* [TextColor](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_TextColor) - Gets or sets the color for the text of the label.
+* [LabelFormat](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_LabelFormat) - Gets or sets the label format. This property is used to set numeric or date-time format to the chart axis label.
+* [LabelAlignment](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartAxisLabelStyle.html#Syncfusion_Maui_Charts_ChartAxisLabelStyle_LabelAlignment) - Gets or sets the axis label at start, end, and center positions.
 
 ## Edge Labels Drawing Mode
 
-Chart axis provides support to customize the rendering position of the edge labels using the [EdgeLabelsDrawingMode](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartAxis.html#Syncfusion_Maui_Charts_ChartAxis_EdgeLabelsDrawingMode) property. [EdgeLabelsDrawingMode](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartAxis.html#Syncfusion_Maui_Charts_ChartAxis_EdgeLabelsDrawingMode) property default value is `Shift`.
+Chart axis provides support to customize the rendering position of the edge labels using the [EdgeLabelsDrawingMode](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartAxis.html#Syncfusion_Maui_Charts_ChartAxis_EdgeLabelsDrawingMode) property. [EdgeLabelsDrawingMode](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartAxis.html#Syncfusion_Maui_Charts_ChartAxis_EdgeLabelsDrawingMode) property default value is [Shift](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.EdgeLabelsDrawingMode.html#Syncfusion_Maui_Charts_EdgeLabelsDrawingMode_Shift).
 
 | Action | Description |
 |--|--|
@@ -102,11 +102,11 @@ chart.XAxes.Add(primaryAxis);
 
 ## Edge Labels Visibility
  
-The visibility of the edge labels of the axis can be controlled using the [EdgeLabelsVisibilityMode](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.RangeAxisBase.html#Syncfusion_Maui_Charts_RangeAxisBase_EdgeLabelsVisibilityMode) property. The default value of [EdgeLabelsVisibilityMode](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.RangeAxisBase.html#Syncfusion_Maui_Charts_RangeAxisBase_EdgeLabelsVisibilityMode) is `Default`, which displays the edge label based on auto interval calculations.
+The visibility of the edge labels of the axis can be controlled using the [EdgeLabelsVisibilityMode](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.RangeAxisBase.html#Syncfusion_Maui_Charts_RangeAxisBase_EdgeLabelsVisibilityMode) property. The default value of [EdgeLabelsVisibilityMode](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.RangeAxisBase.html#Syncfusion_Maui_Charts_RangeAxisBase_EdgeLabelsVisibilityMode) is [Default](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.EdgeLabelsVisibilityMode.html#Syncfusion_Maui_Charts_EdgeLabelsVisibilityMode_Default), which displays the edge label based on auto interval calculations.
 
 **Always Visible**
 
-`AlwaysVisible` option in [EdgeLabelsVisibilityMode](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.RangeAxisBase.html#Syncfusion_Maui_Charts_RangeAxisBase_EdgeLabelsVisibilityMode) is used to view the edge labels even in chart area zoomed state.
+[AlwaysVisible](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.EdgeLabelsVisibilityMode.html#Syncfusion_Maui_Charts_EdgeLabelsVisibilityMode_AlwaysVisible) option in [EdgeLabelsVisibilityMode](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.RangeAxisBase.html#Syncfusion_Maui_Charts_RangeAxisBase_EdgeLabelsVisibilityMode) is used to view the edge labels even in chart area zoomed state.
 
 {% tabs %}
 
@@ -138,7 +138,7 @@ chart.XAxes.Add(primaryAxis);
 
 **Visible**
 
-`Visible` option is used to display the edge labels irrespective of the auto interval calculation until zooming (i.e., in normal state).
+[Visible](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.EdgeLabelsVisibilityMode.html#Syncfusion_Maui_Charts_EdgeLabelsVisibilityMode_Visible) option is used to display the edge labels irrespective of the auto interval calculation until zooming (i.e., in normal state).
 
 {% tabs %}
 

--- a/MAUI/Cartesian-Charts/Axis/Range-padding.md
+++ b/MAUI/Cartesian-Charts/Axis/Range-padding.md
@@ -17,17 +17,17 @@ The [RangePadding](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.Nu
 
 The following types are available for [NumericalAxis](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.NumericalAxis.html) range padding:
 
-* `Additional` - The visible start and end range will be added with an additional interval. 
-* `None` - The visible range sets to exact minimum and maximum value of the items source.
-* `Normal` - The visible range will be the actual range calculated from given items source and series types.
-* `Auto` - Automatically chosen based on the orientation of the axis.
-* `Round` - The visible start and end range round to nearest interval value.
-* `RoundStart` - The visible start range round to nearest interval value.
-* `RoundEnd` - The visible end range round to nearest interval value. 
-* `PrependInterval` - The visible start range will be prepended with an additional interval.
-* `AppendInterval` - The visible end range will be appended with an additional interval.
+* [Additional](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.NumericalPadding.html#Syncfusion_Maui_Charts_NumericalPadding_Additional) - The visible start and end range will be added with an additional interval. 
+* [None](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.NumericalPadding.html#Syncfusion_Maui_Charts_NumericalPadding_None) - The visible range sets to exact minimum and maximum value of the items source.
+* [Normal](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.NumericalPadding.html#Syncfusion_Maui_Charts_NumericalPadding_Normal) - The visible range will be the actual range calculated from given items source and series types.
+* [Auto](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.NumericalPadding.html#Syncfusion_Maui_Charts_NumericalPadding_Auto) - Automatically chosen based on the orientation of the axis.
+* [Round](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.NumericalPadding.html#Syncfusion_Maui_Charts_NumericalPadding_Round) - The visible start and end range round to nearest interval value.
+* [RoundStart](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.NumericalPadding.html#Syncfusion_Maui_Charts_NumericalPadding_RoundStart) - The visible start range round to nearest interval value.
+* [RoundEnd](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.NumericalPadding.html#Syncfusion_Maui_Charts_NumericalPadding_RoundEnd) - The visible end range round to nearest interval value. 
+* [PrependInterval](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.NumericalPadding.html#Syncfusion_Maui_Charts_NumericalPadding_PrependInterval) - The visible start range will be prepended with an additional interval.
+* [AppendInterval](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.NumericalPadding.html#Syncfusion_Maui_Charts_NumericalPadding_AppendInterval) - The visible end range will be appended with an additional interval.
 
-By default, the [RangePadding](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.NumericalAxis.html#Syncfusion_Maui_Charts_NumericalAxis_RangePadding) value for [XAxes](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.SfCartesianChart.html#Syncfusion_Maui_Charts_SfCartesianChart_XAxes) is `Auto` and for [YAxes](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.SfCartesianChart.html#Syncfusion_Maui_Charts_SfCartesianChart_YAxes) is `Round`.
+By default, the [RangePadding](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.NumericalAxis.html#Syncfusion_Maui_Charts_NumericalAxis_RangePadding) value for [XAxes](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.SfCartesianChart.html#Syncfusion_Maui_Charts_SfCartesianChart_XAxes) is [Auto](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.NumericalPadding.html#Syncfusion_Maui_Charts_NumericalPadding_Auto) and for [YAxes](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.SfCartesianChart.html#Syncfusion_Maui_Charts_SfCartesianChart_YAxes) is [Round](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.NumericalPadding.html#Syncfusion_Maui_Charts_NumericalPadding_Round).
 
 **Additional**
 
@@ -150,14 +150,14 @@ chart.YAxes.Add(secondaryAxis);
 
 The [RangePadding](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.DateTimeAxis.html#Syncfusion_Maui_Charts_DateTimeAxis_RangePadding) types available in the [DateTimeAxis](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.DateTimeAxis.html) are: 
 
-* `Auto` - Automatically chosen based on the orientation of the axis.
-* `Additional` - The visible start and end range will be added with an additional interval.
-* `None` - The visible range sets to exact minimum and maximum value of the items source.
-* `Round` - The visible start and end range round to nearest interval value.
-* `RoundStart` - The visible start range round to nearest interval value.
-* `RoundEnd` - The visible end range round to nearest interval value.
-* `PrependInterval` - The visible start range will be prepended with an additional interval.
-* `AppendInterval` - The visible start range will be appended with an additional interval.
+* [Auto](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.DateTimeRangePadding.html#Syncfusion_Maui_Charts_DateTimeRangePadding_Auto) - Automatically chosen based on the orientation of the axis.
+* [Additional](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.DateTimeRangePadding.html#Syncfusion_Maui_Charts_DateTimeRangePadding_Additional) - The visible start and end range will be added with an additional interval.
+* [None](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.DateTimeRangePadding.html#Syncfusion_Maui_Charts_DateTimeRangePadding_None) - The visible range sets to exact minimum and maximum value of the items source.
+* [Round](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.DateTimeRangePadding.html#Syncfusion_Maui_Charts_DateTimeRangePadding_Round) - The visible start and end range round to nearest interval value.
+* [RoundStart](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.DateTimeRangePadding.html#Syncfusion_Maui_Charts_DateTimeRangePadding_RoundStart) - The visible start range round to nearest interval value.
+* [RoundEnd](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.DateTimeRangePadding.html#Syncfusion_Maui_Charts_DateTimeRangePadding_RoundEnd) - The visible end range round to nearest interval value.
+* [PrependInterval](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.DateTimeRangePadding.html#Syncfusion_Maui_Charts_DateTimeRangePadding_PrependInterval) - The visible start range will be prepended with an additional interval.
+* [AppendInterval](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.DateTimeRangePadding.html#Syncfusion_Maui_Charts_DateTimeRangePadding_AppendInterval) - The visible start range will be appended with an additional interval.
 
 **Additional**
 

--- a/MAUI/Cartesian-Charts/Axis/Title.md
+++ b/MAUI/Cartesian-Charts/Axis/Title.md
@@ -59,20 +59,20 @@ chart.YAxes.Add(secondaryAxis);
 
 The [Title](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartAxis.html#Syncfusion_Maui_Charts_ChartAxis_Title) property in axis provides options to customize the text and font of axis title. Axis does not display title by default. The title can be customized using following properties,
 
-* `Text` - Gets or sets the title for axis.
-* `Background` - Gets or sets the background color of the labels.
-* `CornerRadius` - Gets or sets a value that defines the rounded corners for labels.
-* `FontAttributes` - Gets or sets the font style for the label.
-* `FontFamily` - Gets or sets the font family name for the label.
-* `FontSize` - Gets or sets the font size for the label.
-* `Margin` - Gets or sets the margin of the label to customize the appearance of label. 
-* `Stroke` - Gets or sets the border stroke color of the labels.
-* `StrokeWidth` - Gets or sets the border thickness of the label.
-* `TextColor` - Gets or sets the color for the text of the label.
+* [Text](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartAxisTitle.html#Syncfusion_Maui_Charts_ChartAxisTitle_Text) - Gets or sets the title for axis.
+* [Background](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_Background) - Gets or sets the background color of the labels.
+* [CornerRadius](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_CornerRadius) - Gets or sets a value that defines the rounded corners for labels.
+* [FontAttributes](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_FontAttributes) - Gets or sets the font style for the label.
+* [FontFamily](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_FontFamily) - Gets or sets the font family name for the label.
+* [FontSize](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_FontSize) - Gets or sets the font size for the label.
+* [Margin](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_Margin) - Gets or sets the margin of the label to customize the appearance of label. 
+* [Stroke](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_Stroke) - Gets or sets the border stroke color of the labels.
+* [StrokeWidth](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_StrokeWidth) - Gets or sets the border thickness of the label.
+* [TextColor](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_TextColor) - Gets or sets the color for the text of the label.
 
 ## Label extent
 
-The [LabelExtent]() property allows to set the gap between axis labels and title. This is typically used to maintain the fixed gap between axis labels and title when the digits of the axis value changed in live update.
+The [LabelExtent](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartAxis.html#Syncfusion_Maui_Charts_ChartAxis_LabelExtent) property allows to set the gap between axis labels and title. This is typically used to maintain the fixed gap between axis labels and title when the digits of the axis value changed in live update.
 
 {% tabs %}
 

--- a/MAUI/Cartesian-Charts/Axis/Types.md
+++ b/MAUI/Cartesian-Charts/Axis/Types.md
@@ -11,10 +11,10 @@ documentation: ug
 
 Cartesian chart supports the following types of chart axis.
 
-* NumericalAxis
-* CategoryAxis
-* DateTimeAxis
-* LogarithmicAxis
+* [NumericalAxis](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.NumericalAxis.html)
+* [CategoryAxis](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.CategoryAxis.html)
+* [DateTimeAxis](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.DateTimeAxis.html)
+* [LogarithmicAxis](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.LogarithmicAxis.html)
 
 ## Numerical Axis
 
@@ -675,7 +675,7 @@ In the above image, the [ColumnSeries](https://help.syncfusion.com/cr/maui/Syncf
 
 ## Axis Crossing
 
-The chart allows you to customize the origin, by default the axis will be rendered with (0,0) as the origin in x and y-axes. An axis can be positioned anywhere in the chart area by using the [CrossesAt](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartAxis.html#Syncfusion_Maui_Charts_ChartAxis_CrossesAt) property. This property specifies where the horizontal axis intersects or crosses the vertical axis, and vice versa. The default value of the CrossesAt property is `double.NaN`.
+The chart allows you to customize the origin, by default the axis will be rendered with (0,0) as the origin in x and y-axes. An axis can be positioned anywhere in the chart area by using the [CrossesAt](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartAxis.html#Syncfusion_Maui_Charts_ChartAxis_CrossesAt) property. This property specifies where the horizontal axis intersects or crosses the vertical axis, and vice versa. The default value of the [CrossesAt](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartAxis.html#Syncfusion_Maui_Charts_ChartAxis_CrossesAt) property is `double.NaN`.
 
 {% tabs %}
 

--- a/MAUI/Cartesian-Charts/BoxAndWhisker.md
+++ b/MAUI/Cartesian-Charts/BoxAndWhisker.md
@@ -226,7 +226,6 @@ The Median values of given dataset is viewed by enabling the [ShowMedian](https:
 ![ShowMedian in MAUI chart](Chart-types_images/ShowMedian.png)
 
 N>
-
  * The middle number of data points is the median for the odd number of data points.
  * The average of the middle two numbers is a median for the even number of data points.
 

--- a/MAUI/Cartesian-Charts/Errorbar-Chart.md
+++ b/MAUI/Cartesian-Charts/Errorbar-Chart.md
@@ -87,7 +87,7 @@ The following code examples illustrates how to create error bar series:
 The error bar mode specifies whether the error bar should be drawn horizontally, vertically or both. The [Mode](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ErrorBarSeries.html#Syncfusion_Maui_Charts_ErrorBarSeries_Mode) property used to switch the error bar mode. By default, the Mode value is [Both](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ErrorBarMode.html#Syncfusion_Maui_Charts_ErrorBarMode_Both), which will display both horizontal and vertical error values.
 
 ### Both
-To view both the horizontal and vertical error value, you can set the Mode as Both as shown in the following code example.
+To view both the horizontal and vertical error value, you can set the Mode as [Both](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ErrorBarMode.html#Syncfusion_Maui_Charts_ErrorBarMode_Both) as shown in the following code example.
 
 {% tabs %}
 
@@ -126,7 +126,7 @@ To view both the horizontal and vertical error value, you can set the Mode as Bo
 
 ### Horizontal
 
-To view horizontal error value, you can set the Mode as Horizontal as shown in the following code example.
+To view horizontal error value, you can set the Mode as [Horizontal](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ErrorBarMode.html#Syncfusion_Maui_Charts_ErrorBarMode_Horizontal) as shown in the following code example.
 
 {% tabs %}
 
@@ -164,7 +164,7 @@ To view horizontal error value, you can set the Mode as Horizontal as shown in t
 
 ### Vertical
 
-To view vertical error value, you can set the Mode as Vertical, as shown in the below code example.
+To view vertical error value, you can set the Mode as [Vertical](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ErrorBarMode.html#Syncfusion_Maui_Charts_ErrorBarMode_Vertical), as shown in the below code example.
 
 {% tabs %}
 
@@ -207,11 +207,11 @@ The [HorizontalDirection](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Ch
 
 [ErrorBarDirection](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ErrorBarDirection.html) contains below values:
 
-*`Both` -  It indicates the actual data point value along with specific amount of positive and negative error values.
+* [`Both`](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ErrorBarDirection.html#Syncfusion_Maui_Charts_ErrorBarDirection_Both) -  It indicates the actual data point value along with specific amount of positive and negative error values.
 
-*`Plus` -  It indicates the actual data point value along with specific amount of positive error value.
+* [`Plus`](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ErrorBarDirection.html#Syncfusion_Maui_Charts_ErrorBarDirection_Plus) -  It indicates the actual data point value along with specific amount of positive error value.
 
-*`Minus`-  It indicates the actual data point value along with specific amount of negative error value.
+* [`Minus`](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ErrorBarDirection.html#Syncfusion_Maui_Charts_ErrorBarDirection_Minus) -  It indicates the actual data point value along with specific amount of negative error value.
 
 The following code illustrates how to set the [HorizontalDirection](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ErrorBarSeries.html#Syncfusion_Maui_Charts_ErrorBarSeries_HorizontalDirection) and the [VerticalDirection](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ErrorBarSeries.html#Syncfusion_Maui_Charts_ErrorBarSeries_VerticalDirection) values to error bar chart.
 
@@ -253,7 +253,7 @@ The following code illustrates how to set the [HorizontalDirection](https://help
 
 ## Type
 
-The [Type](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ErrorBarSeries.html#Syncfusion_Maui_Charts_ErrorBarSeries_Type) property is used to define the error bar type value in [Fixed](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ErrorBarType.html#Syncfusion_Maui_Charts_ErrorBarType_Fixed), [Custom](), [Percentage](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ErrorBarType.html#Syncfusion_Maui_Charts_ErrorBarType_Percentage), [StandardDeviation](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ErrorBarType.html#Syncfusion_Maui_Charts_ErrorBarType_StandardDeviation), and [StandardErrors](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ErrorBarType.html#Syncfusion_Maui_Charts_ErrorBarType_StandardError). The default value of this property is [Fixed](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ErrorBarType.html#Syncfusion_Maui_Charts_ErrorBarType_Fixed). For all types, You have to set the values for [HorizontalErrorValue](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ErrorBarSeries.html#Syncfusion_Maui_Charts_ErrorBarSeries_HorizontalErrorValue) and [VerticalErrorValue](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ErrorBarSeries.html#Syncfusion_Maui_Charts_ErrorBarSeries_VerticalErrorValue) except [Custom](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ErrorBarType.html#Syncfusion_Maui_Charts_ErrorBarType_Custom).
+The [Type](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ErrorBarSeries.html#Syncfusion_Maui_Charts_ErrorBarSeries_Type) property is used to define the error bar type value in [Fixed](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ErrorBarType.html#Syncfusion_Maui_Charts_ErrorBarType_Fixed), [Custom](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ErrorBarType.html#Syncfusion_Maui_Charts_ErrorBarType_Custom), [Percentage](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ErrorBarType.html#Syncfusion_Maui_Charts_ErrorBarType_Percentage), [StandardDeviation](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ErrorBarType.html#Syncfusion_Maui_Charts_ErrorBarType_StandardDeviation), and [StandardErrors](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ErrorBarType.html#Syncfusion_Maui_Charts_ErrorBarType_StandardError). The default value of this property is [Fixed](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ErrorBarType.html#Syncfusion_Maui_Charts_ErrorBarType_Fixed). For all types, You have to set the values for [HorizontalErrorValue](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ErrorBarSeries.html#Syncfusion_Maui_Charts_ErrorBarSeries_HorizontalErrorValue) and [VerticalErrorValue](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ErrorBarSeries.html#Syncfusion_Maui_Charts_ErrorBarSeries_VerticalErrorValue) except [Custom](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ErrorBarType.html#Syncfusion_Maui_Charts_ErrorBarType_Custom).
 
 ### Fixed
 
@@ -401,7 +401,7 @@ The [Type](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ErrorBarSe
 
 ### Custom
 
-If the Type is Custom, you have to bind the [HorizontalErrorPath](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ErrorBarSeries.html#Syncfusion_Maui_Charts_ErrorBarSeries_HorizontalErrorPath) and the [VerticalErrorPath](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ErrorBarSeries.html#Syncfusion_Maui_Charts_ErrorBarSeries_VerticalErrorPath) as shown in the following code sample.
+If the Type is [Custom](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ErrorBarType.html#Syncfusion_Maui_Charts_ErrorBarType_Custom), you have to bind the [HorizontalErrorPath](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ErrorBarSeries.html#Syncfusion_Maui_Charts_ErrorBarSeries_HorizontalErrorPath) and the [VerticalErrorPath](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ErrorBarSeries.html#Syncfusion_Maui_Charts_ErrorBarSeries_VerticalErrorPath) as shown in the following code sample.
 
 {% tabs %}
 

--- a/MAUI/Cartesian-Charts/Fastline.md
+++ b/MAUI/Cartesian-Charts/Fastline.md
@@ -124,7 +124,7 @@ this.Content = chart;
 
 ### Anti-aliasing
 
-There may be some jagged lines at the edges. This can be reduced by using the `EnableAntiAliasing` property.
+There may be some jagged lines at the edges. This can be reduced by using the [EnableAntiAliasing](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.FastLineSeries.html#Syncfusion_Maui_Charts_FastLineSeries_EnableAntiAliasing) property.
 
 {% tabs %}
 

--- a/MAUI/Cartesian-Charts/Get-the-touch-position-in-chart.md
+++ b/MAUI/Cartesian-Charts/Get-the-touch-position-in-chart.md
@@ -9,11 +9,11 @@ documentation: ug
 
 # Get the touch position in SfCartesianChart
 
-ChartInteractiveBehavior provides the following override methods to get the x and y positions when touching the [`SfCartesianChart`](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.SfCartesianChart.html?tabs=tabid-1).
+[ChartInteractiveBehavior](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartInteractiveBehavior.html) provides the following override methods to get the x and y positions when touching the [`SfCartesianChart`](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.SfCartesianChart.html?tabs=tabid-1).
 
-* [`OnTouchUp`]() - Called when a user lifts their finger or releases their touch input from the Chart area. 
-* [`OnTouchMove`]() - Called when a user's finger or touch input device is in contact with the Chart area and moves across its surface.
-* [`OnTouchDown`]() -  Called when the user makes the initial contact of a user's finger or touch input device with the Chart Area.
+* [`OnTouchUp`](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartBehavior.html#Syncfusion_Maui_Charts_ChartBehavior_OnTouchUp_Syncfusion_Maui_Charts_ChartBase_System_Single_System_Single_) - Called when a user lifts their finger or releases their touch input from the Chart area. 
+* [`OnTouchMove`](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartBehavior.html#Syncfusion_Maui_Charts_ChartBehavior_OnTouchMove_Syncfusion_Maui_Charts_ChartBase_System_Single_System_Single_) - Called when a user's finger or touch input device is in contact with the Chart area and moves across its surface.
+* [`OnTouchDown`](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartBehavior.html#Syncfusion_Maui_Charts_ChartBehavior_OnTouchDown_Syncfusion_Maui_Charts_ChartBase_System_Single_System_Single_) -  Called when the user makes the initial contact of a user's finger or touch input device with the Chart Area.
 
 {% tabs %}
 
@@ -70,3 +70,5 @@ ChartInteractiveBehavior provides the following override methods to get the x an
 
 {% endtabs %}
 
+To enhance your understanding, you can explore  
+[How to Add Data Points on Interactions in .NET MAUI Chart (SfCartesianChart)?](https://support.syncfusion.com/kb/article/13602/how-to-add-data-points-on-interactions-in-net-maui-chart-sfcartesianchart)

--- a/MAUI/Cartesian-Charts/Line.md
+++ b/MAUI/Cartesian-Charts/Line.md
@@ -214,10 +214,10 @@ The [Type](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.SplineSeri
 
 The following types are used in SplineSeries:
 
-* `Natural`
-* `Monotonic`
-* `Cardinal`
-* `Clamped`
+* [Natural](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.SplineType.html#Syncfusion_Maui_Charts_SplineType_Natural)
+* [Monotonic](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.SplineType.html#Syncfusion_Maui_Charts_SplineType_Monotonic)
+* [Cardinal](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.SplineType.html#Syncfusion_Maui_Charts_SplineType_Cardinal)
+* [Clamped](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.SplineType.html#Syncfusion_Maui_Charts_SplineType_Clamped)
 
 {% tabs %}
 
@@ -324,7 +324,7 @@ this.Content= chart;
 
 In order to change the series markers appearance, create an instance of the [MarkerSettings](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.LineSeries.html#Syncfusion_Maui_Charts_LineSeries_MarkerSettings) property. The following properties are used to customize marker appearance.
 
-* [Type](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_Type), of type `ShapeType`, describes the shape of the series marker. The default value of this property is [ShapeType.Circle]().
+* [Type](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_Type), of type `ShapeType`, describes the shape of the series marker. The default value of this property is [ShapeType.Circle](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ShapeType.html#Syncfusion_Maui_Charts_ShapeType_Circle).
 * [Stroke](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_Stroke), of type `Brush`, indicates the brush used to paint the marker border.
 * [StrokeWidth](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_StrokeWidth), of type `double`, indicates the width of the marker border.
 * [Fill](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_Fill), of type `Brush`, indicates the color of the marker.

--- a/MAUI/Cartesian-Charts/RangeArea.md
+++ b/MAUI/Cartesian-Charts/RangeArea.md
@@ -113,7 +113,7 @@ A marker, also known as a symbol, is used to determine or highlight the position
 
 In order to change the series markers’ appearance, create an instance of the [MarkerSettings](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.RangeAreaSeries.html#Syncfusion_Maui_Charts_RangeAreaSeries_MarkerSettings) property. The following properties are used to customize marker appearance.
 
-* [Type](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_Type), of type `ShapeType`, describes the shape of the series marker. The default value of this property is the [ShapeType.Circle]().
+* [Type](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_Type), of type `ShapeType`, describes the shape of the series marker. The default value of this property is the [ShapeType.Circle](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ShapeType.html#Syncfusion_Maui_Charts_ShapeType_Circle).
 * [Stroke](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_Stroke), of type `Brush`, indicates the brush used to paint the marker border.
 * [StrokeWidth](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_StrokeWidth), of type `double`, indicates the width of the marker border.
 * [Fill](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_Fill), of type `Brush`, indicates the color of the marker.

--- a/MAUI/Cartesian-Charts/Selection.md
+++ b/MAUI/Cartesian-Charts/Selection.md
@@ -115,10 +115,10 @@ The following properties are used to customize the [ChartSelectionBehavior](http
 
 * [Type](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartSelectionBehavior.html#Syncfusion_Maui_Charts_ChartSelectionBehavior_Type) - Gets or sets the [ChartSelectionType](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartSelectionType.html) for the selection behavior.     
 Chart selection types:
-    * `Single` - The user can select only one item at a time
-    * `SingleDeselect` - The user can select and deselect only one item at a time.
-    * `Multiple` - The user can select and deselect multiple items at a time.
-    * `None` - The user can't select any item.
+    * [Single](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartSelectionType.html#Syncfusion_Maui_Charts_ChartSelectionType_Single) - The user can select only one item at a time
+    * [SingleDeselect](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartSelectionType.html#Syncfusion_Maui_Charts_ChartSelectionType_SingleDeselect) - The user can select and deselect only one item at a time.
+    * [Multiple](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartSelectionType.html#Syncfusion_Maui_Charts_ChartSelectionType_Multiple) - The user can select and deselect multiple items at a time.
+    * [None](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartSelectionType.html#Syncfusion_Maui_Charts_ChartSelectionType_None) - The user can't select any item.
 * [SelectionBrush](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartSelectionBehavior.html#Syncfusion_Maui_Charts_ChartSelectionBehavior_SelectionBrush) - Gets or sets the brush color for the selection.
 * [SelectedIndex](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartSelectionBehavior.html#Syncfusion_Maui_Charts_ChartSelectionBehavior_SelectedIndex) - Gets or sets the value of the index to be selected.
 * [SelectedIndexes](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartSelectionBehavior.html#Syncfusion_Maui_Charts_ChartSelectionBehavior_SelectedIndexes) - Gets or sets the list of indexes to be selected.

--- a/MAUI/Cartesian-Charts/StepArea.md
+++ b/MAUI/Cartesian-Charts/StepArea.md
@@ -102,7 +102,7 @@ this.Content= chart;
 
 To change the series markers appearance, create an instance of the [MarkerSettings](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.AreaSeries.html#Syncfusion_Maui_Charts_AreaSeries_MarkerSettings) property. The following properties are used to customize marker appearance.
 
-* [Type](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_Type), of type `ShapeType`, describes the shape of the series marker. The default value of this property is [ShapeType.Circle]().
+* [Type](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_Type), of type `ShapeType`, describes the shape of the series marker. The default value of this property is [ShapeType.Circle](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ShapeType.html#Syncfusion_Maui_Charts_ShapeType_Circle).
 * [Stroke](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_Stroke), of type `Brush`, indicates the brush used to paint the marker border.
 * [StrokeWidth](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_StrokeWidth), of type `double`, indicates the width of the marker border.
 * [Fill](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_Fill), of type `Brush`, indicates the color of the marker.

--- a/MAUI/Cartesian-Charts/Tooltip.md
+++ b/MAUI/Cartesian-Charts/Tooltip.md
@@ -228,7 +228,7 @@ You can show or hide the chart tooltip programmatically by using the show or hid
 
 ### Show method
 
-The [Show]() method is used to activate the tooltip at the specified location.
+The [Show](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartTooltipBehavior.html#Syncfusion_Maui_Charts_ChartTooltipBehavior_Show_System_Single_System_Single_System_Boolean_) method is used to activate the tooltip at the specified location.
 
 {% tabs %}
 
@@ -244,6 +244,26 @@ The [Show]() method is used to activate the tooltip at the specified location.
 
     <Button Text="Show tooltip" Clicked="Button_Clicked"></Button>
 
+{% endhighlight %}
+
+{% highlight C# %}
+
+    Stacklayout layout = new Stacklayout();
+    
+    SfCartesianChart chart = new SfCartesianChart();
+    .....
+    ChartTooltipBehavior tooltipBehavior = new ChartTooltipBehavior();
+    chart.TooltipBehavior = tooltipBehavior;
+    .....
+    Button button = new Button()
+    {
+        Text = "Show Tooltip",         
+    };
+    button.Clicked += Button_Clicked;
+    
+    layout.Add(chart);
+    layout.Add(button);
+    
 {% endhighlight %}
 
 {% endtabs %}
@@ -267,7 +287,7 @@ N> The tooltip will be activated at the specified location only if there is any 
 
 ### Hide method
 
-The [Hide]() method is used to hide the tooltip programmatically.
+The [Hide](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartTooltipBehavior.html#Syncfusion_Maui_Charts_ChartTooltipBehavior_Hide) method is used to hide the tooltip programmatically.
 
 {% tabs %}
 

--- a/MAUI/Cartesian-Charts/Trackball.md
+++ b/MAUI/Cartesian-Charts/Trackball.md
@@ -50,8 +50,8 @@ this.Content = chart;
 
 The [DisplayMode](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartTrackballBehavior.html#Syncfusion_Maui_Charts_ChartTrackballBehavior_DisplayMode) property specifies whether a label should be displayed for all data points along the trackball line or only the nearest data point label. The following choices are available for this property.
 
-* `FloatAllPoints` – Displays labels for all the data points along the vertical line.
-* `NearestPoint` – Displays label for a single data point nearer to the touch point on the chart area.
+* [FloatAllPoints](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.LabelDisplayMode.html#Syncfusion_Maui_Charts_LabelDisplayMode_FloatAllPoints) – Displays labels for all the data points along the vertical line.
+* [NearestPoint](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.LabelDisplayMode.html#Syncfusion_Maui_Charts_LabelDisplayMode_NearestPoint) – Displays label for a single data point nearer to the touch point on the chart area.
 
 {% tabs %}
 
@@ -87,16 +87,16 @@ The [DisplayMode](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.Cha
 
 The [LabelStyle](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartTrackballBehavior.html#Syncfusion_Maui_Charts_ChartTrackballBehavior_LabelStyle) property provides to customize the trackball labels. These options are:
 
-* `Background`, of type `Brush`, used to change the label background color.
-* `Margin`, of type `Thickness`, used to change the margin of the label.
-* `TextColor`, of type `Color`, used to change the text color.
-* `StrokeWidth`, of type `double`, used to change the stroke thickness of the label.
-* `Stroke`, of type `Brush`, used to customize the border of the label.
-* `LabelFormat`, of type `string`, used to change the format of the label.
-* `FontFamily`, of type `string`, used to change the font family for the trackball label.
-* `FontAttributes`, of type `FontAttributes`, used to change the font style for the trackball label.
-* `FontSize`, of type `double`, used to change the font size for the trackball label.
-* `CornerRadius`, of type `CornerRadius`, used to set the rounded corners for labels.
+* [Background](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_Background), of type `Brush`, used to change the label background color.
+* [Margin](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_Margin), of type `Thickness`, used to change the margin of the label.
+* [TextColor](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_TextColor), of type `Color`, used to change the text color.
+* [StrokeWidth](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_StrokeWidth), of type `double`, used to change the stroke thickness of the label.
+* [Stroke](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_Stroke), of type `Brush`, used to customize the border of the label.
+* [LabelFormat](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_LabelFormat), of type `string`, used to change the format of the label.
+* [FontFamily](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_FontFamily), of type `string`, used to change the font family for the trackball label.
+* [FontAttributes](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_FontAttributes), of type `FontAttributes`, used to change the font style for the trackball label.
+* [FontSize](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_FontSize), of type `double`, used to change the font size for the trackball label.
+* [CornerRadius](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_CornerRadius), of type `CornerRadius`, used to set the rounded corners for labels.
 
 
 {% tabs %}
@@ -138,9 +138,9 @@ this.Content = chart;
 
  The [LineStyle](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartTrackballBehavior.html#Syncfusion_Maui_Charts_ChartTrackballBehavior_LineStyle) property provides to customize the trackball line. These options are:
 
-* `StrokeWidth`, of type `double`, used to change the stroke width of the line.
-* `Stroke`, of type `Brush`, used to change the stroke color of the line.
-* `StrokeDashArray`, of type `DoubleCollection`, specifies the dashes to be applied on the line.
+* [StrokeWidth](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLineStyle.html#Syncfusion_Maui_Charts_ChartLineStyle_StrokeWidth), of type `double`, used to change the stroke width of the line.
+* [Stroke](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLineStyle.html#Syncfusion_Maui_Charts_ChartLineStyle_Stroke), of type `Brush`, used to change the stroke color of the line.
+* [StrokeDashArray](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLineStyle.html#Syncfusion_Maui_Charts_ChartLineStyle_StrokeDashArray), of type `DoubleCollection`, specifies the dashes to be applied on the line.
 
 {% tabs %}
 
@@ -175,12 +175,12 @@ this.Content = chart;
 
 The [MarkerSettings](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartTrackballBehavior.html#Syncfusion_Maui_Charts_ChartTrackballBehavior_MarkerSettings) property provides to customize the trackball markers. The trackball marker can be customised using the following properties.
 
-* `Type`, of type `ShapeType`, used to set the marker shape type.
-* `Stroke`, of type `Brush`, used to change the marker border color.
-* `Fill`, of type `Brush`, used to change the marker background color.
-* `StrokeWidth`, of type `double`, used to change the width of the marker border.
-* `Width`, of type `double`, used to change the width of the marker.
-* `Height`, of type `double`, used to change the height of the marker.
+* [Type](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_Type), of type `ShapeType`, used to set the marker shape type.
+* [Stroke](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_Stroke), of type `Brush`, used to change the marker border color.
+* [Fill](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_Fill), of type `Brush`, used to change the marker background color.
+* [StrokeWidth](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_StrokeWidth), of type `double`, used to change the width of the marker border.
+* [Width](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_Width), of type `double`, used to change the width of the marker.
+* [Height](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_Height), of type `double`, used to change the height of the marker.
 
 {% tabs %}
 

--- a/MAUI/Cartesian-Charts/Transform-axis-value-to-pixel-value-and-vice-versa.md
+++ b/MAUI/Cartesian-Charts/Transform-axis-value-to-pixel-value-and-vice-versa.md
@@ -11,8 +11,8 @@ documentation: ug
 
 [`SfCartesianChart`](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.SfCartesianChart.html?tabs=tabid-1) offers two utility methods to transform the pixel into a chart point and vice-versa.
 
-* [`ValueToPoint(ChartAxis axis,double value)`]() - Converts the data point value to the screen point.
-* [`PointToValue(ChartAxis axis,double x, double y)`]() - Converts the screen point to the chart value.
+* [`ValueToPoint(ChartAxis axis,double value)`](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.SfCartesianChart.html#Syncfusion_Maui_Charts_SfCartesianChart_ValueToPoint_Syncfusion_Maui_Charts_ChartAxis_System_Double_) - Converts the data point value to the screen point.
+* [`PointToValue(ChartAxis axis,double x, double y)`](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.SfCartesianChart.html#Syncfusion_Maui_Charts_SfCartesianChart_PointToValue_Syncfusion_Maui_Charts_ChartAxis_System_Double_System_Double_) - Converts the screen point to the chart value.
 
 {% tabs %}
 

--- a/MAUI/Cartesian-Charts/Zooming-and-panning.md
+++ b/MAUI/Cartesian-Charts/Zooming-and-panning.md
@@ -81,7 +81,7 @@ chart.ZoomPanBehavior = zooming;
 
 ### Directional Zooming
 
-The directional Zooming feature enhances your zooming experience by allowing you to zoom in and out in a specific direction. This feature is enabled by setting the [EnableDirectionalZooming]() property to `true` as shown in the following code sample. The default value of this property is false.
+The directional Zooming feature enhances your zooming experience by allowing you to zoom in and out in a specific direction. This feature is enabled by setting the [EnableDirectionalZooming](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartZoomPanBehavior.html#Syncfusion_Maui_Charts_ChartZoomPanBehavior_EnableDirectionalZooming) property to `true` as shown in the following code sample. The default value of this property is false.
 
 {% tabs %}
 
@@ -252,7 +252,7 @@ chart.ZoomPanBehavior = zooming;
 
 ## Selection zooming
 
-Selection zooming feature allows users to interactively choose a particular area of the chart and zoom in. By specifying the [EnableSelectionZooming]() property to `true` as shown in the following code sample, you can double tap and drag to select a range on the chart to be zoomed in. The default value of this property is false.
+Selection zooming feature allows users to interactively choose a particular area of the chart and zoom in. By specifying the [EnableSelectionZooming](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartZoomPanBehavior.html#Syncfusion_Maui_Charts_ChartZoomPanBehavior_EnableSelectionZooming) property to `true` as shown in the following code sample, you can double tap and drag to select a range on the chart to be zoomed in. The default value of this property is false.
 
 N> To perform selection zooming on a desktop, hold the left mouse button, double-click, and drag. For mobile, hold your finger, double-click, and drag to create a selection rectangle.
 
@@ -290,29 +290,29 @@ chart.ZoomPanBehavior = zooming;
 
 You can customize the selection rectangle using the following properties:
 
-* [SelectionRectStrokeWidth]() – Get or set the stroke width for selection rectangle.
+* [SelectionRectStrokeWidth](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartZoomPanBehavior.html#Syncfusion_Maui_Charts_ChartZoomPanBehavior_SelectionRectStrokeWidth) – Get or set the stroke width for selection rectangle.
 
-* [SelectionRectStroke]() - Get or set the stroke color for selection rectangle.
+* [SelectionRectStroke](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartZoomPanBehavior.html#Syncfusion_Maui_Charts_ChartZoomPanBehavior_SelectionRectStroke) - Get or set the stroke color for selection rectangle.
 
-* [SelectionRectStrokeDashArray]() - Get or set the stroke dashes for selection rectangle.
+* [SelectionRectStrokeDashArray](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartZoomPanBehavior.html#Syncfusion_Maui_Charts_ChartZoomPanBehavior_SelectionRectStrokeDashArray) - Get or set the stroke dashes for selection rectangle.
 
-* [SelectionRectFill]() - Get or set the fill color for the selection rectangle.
+* [SelectionRectFill](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartZoomPanBehavior.html#Syncfusion_Maui_Charts_ChartZoomPanBehavior_SelectionRectFill) - Get or set the fill color for the selection rectangle.
 
 ### Show trackball axis label
-The selection zooming trackball axis label is enabled by setting the [ShowTrackballLabel](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartAxis.html#Syncfusion_Maui_Charts_ChartAxis_ShowTrackballLabel) property to `true`. The default value of the [ShowTrackballLabel](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartAxis.html#Syncfusion_Maui_Charts_ChartAxis_ShowTrackballLabel) is `false`. The TrackballLabelStyle[] property provides to customize the trackball axis labels. These options are:
+The selection zooming trackball axis label is enabled by setting the [ShowTrackballLabel](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartAxis.html#Syncfusion_Maui_Charts_ChartAxis_ShowTrackballLabel) property to `true`. The default value of the [ShowTrackballLabel](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartAxis.html#Syncfusion_Maui_Charts_ChartAxis_ShowTrackballLabel) is `false`. The [TrackballLabelStyle](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartAxis.html#Syncfusion_Maui_Charts_ChartAxis_TrackballLabelStyle) property provides to customize the trackball axis labels. These options are:
 
-* `Background`, of type `Brush`, describes the background color of the labels.
-* `CornerRadius`, of type `CornerRadius`, describes the corner radius of the label's border.
-* `FontAttributes`, of type `FontAttributes`, determines text style.
-* `FontFamily`, of type `string`, defines the font family of the label.
-* `FontSize`, of type `double`, defines the font size of the labels.
-* `Margin`, of type `Thickness`, used to change the margin of the labels. 
-* `Stroke`, of type `Brush`, describes the border stroke color of the labels.
-* `StrokeWidth`, of type `double`, defines the border thickness of the label.
-* `TextColor` of type `Color`, describes the color of the label's text.
-* `LabelFormat` of type `string`, defines the label format. This property is used to set numeric or date-time format to the chart axis label.
+* [Background](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_Background), of type `Brush`, describes the background color of the labels.
+* [CornerRadius](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_CornerRadius), of type `CornerRadius`, describes the corner radius of the label's border.
+* [FontAttributes](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_FontAttributes), of type `FontAttributes`, determines text style.
+* [FontFamily](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_FontFamily), of type `string`, defines the font family of the label.
+* [FontSize](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_FontSize), of type `double`, defines the font size of the labels.
+* [Margin](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_Margin), of type `Thickness`, used to change the margin of the labels. 
+* [Stroke](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_Stroke), of type `Brush`, describes the border stroke color of the labels.
+* [StrokeWidth](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_StrokeWidth), of type `double`, defines the border thickness of the label.
+* [TextColor](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_TextColor) of type `Color`, describes the color of the label's text.
+* [LabelFormat](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLabelStyle.html#Syncfusion_Maui_Charts_ChartLabelStyle_LabelFormat) of type `string`, defines the label format. This property is used to set numeric or date-time format to the chart axis label.
 
-N> If the axis labels in the selection zooming trackball are cropped or hidden, you should use the [LabelExtent]() property to extend the space between the axis labels and the axis title accordingly.
+N> If the axis labels in the selection zooming trackball are cropped or hidden, you should use the [LabelExtent](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartAxis.html#Syncfusion_Maui_Charts_ChartAxis_LabelExtent) property to extend the space between the axis labels and the axis title accordingly.
 
 The following code sample illustrates how enable to axis trackball label while selection zooming.
 

--- a/MAUI/Cartesian-Charts/migration.md
+++ b/MAUI/Cartesian-Charts/migration.md
@@ -179,7 +179,7 @@ The following table illustrates the API migration for the chart.
 </tr>
 <tr>
 <td>LabelExtent</td>
-<td><em>LabelExtent</em></td>
+<td>LabelExtent</td>
 </tr>
 <tr>
 <td>LabelClicked</td>

--- a/MAUI/Circular-Charts/Overview.md
+++ b/MAUI/Circular-Charts/Overview.md
@@ -9,7 +9,7 @@ documentation: ug
 
 # .NET MAUI Chart Overview
 
-Syncfusion .NET MAUI Charts (SfCircularChart) is used to create the chart with beautiful and enhanced UI visualization of data that are used in high-quality .NET MAUI applications.
+Syncfusion .NET MAUI Charts ([SfCircularChart](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.SfCircularChart.html)) is used to create the chart with beautiful and enhanced UI visualization of data that are used in high-quality .NET MAUI applications.
 
 ## Key features
 

--- a/MAUI/Circular-Charts/Selection.md
+++ b/MAUI/Circular-Charts/Selection.md
@@ -52,10 +52,10 @@ The following properties are used to customize the [ChartSelectionBehavior](http
 
 * [Type](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartSelectionBehavior.html#Syncfusion_Maui_Charts_ChartSelectionBehavior_Type) - Gets or sets the [ChartSelectionType](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartSelectionType.html) for the selection behavior.     
 Chart selection types:
-    * `Single` - The user can select only one item at a time
-    * `SingleDeselect` - The user can select and deselect only one item at a time.
-    * `Multiple` - The user can select and deselect multiple items at a time.
-    * `None` - The user can't select any item.
+    * [Single](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartSelectionType.html#Syncfusion_Maui_Charts_ChartSelectionType_Single) - The user can select only one item at a time
+    * [SingleDeselect](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartSelectionType.html#Syncfusion_Maui_Charts_ChartSelectionType_SingleDeselect) - The user can select and deselect only one item at a time.
+    * [Multiple](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartSelectionType.html#Syncfusion_Maui_Charts_ChartSelectionType_Multiple) - The user can select and deselect multiple items at a time.
+    * [None](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartSelectionType.html#Syncfusion_Maui_Charts_ChartSelectionType_None) - The user can't select any item.
 * [SelectionBrush](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartSelectionBehavior.html#Syncfusion_Maui_Charts_ChartSelectionBehavior_SelectionBrush) - Gets or sets the brush color for the selection.
 * [SelectedIndex](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartSelectionBehavior.html#Syncfusion_Maui_Charts_ChartSelectionBehavior_SelectedIndex) - Gets or sets the value of the index to be selected.
 * [SelectedIndexes](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartSelectionBehavior.html#Syncfusion_Maui_Charts_ChartSelectionBehavior_SelectedIndexes) - Gets or sets the list of indexes to be selected.


### PR DESCRIPTION
**Description**

Updated user guide APIs for missing API reference link in .Net Maui Chart control, rearranged the sample code alignment, updated the missing C# code in tooltip show method and update the KB link ([How to add the Data points on interaction in .Net maui chart](https://support.syncfusion.com/kb/article/13602/how-to-add-data-points-on-interactions-in-net-maui-chart-sfcartesianchart)) for reference in Get the touch position in chart document.  