### PR TITLE
SEO-176405 .NET MAUI Numeric Entry Interlinking

### DIFF
--- a/MAUI/NumericEntry/Getting-Started.md
+++ b/MAUI/NumericEntry/Getting-Started.md
@@ -268,6 +268,4 @@ private void sfNumericEntry_ValueChanged(object sender, NumericEntryValueChanged
 {% endhighlight %}
 {% endtabs %}
 
-You can find the complete getting started sample of .NET MAUI from this [link.](https://github.com/SyncfusionExamples/maui-numericentry-samples)
-
-N> You can refer to our [.NET MAUI Numeric Entry](https://www.syncfusion.com/maui-controls/maui-numeric-entry) feature tour page for its groundbreaking feature representations.
+N> You can refer to our [.NET MAUI Numeric Entry](https://www.syncfusion.com/maui-controls/maui-numeric-entry) feature tour page for its groundbreaking feature representations. You can also explore our [.NET MAUI Combobox Example](https://github.com/SyncfusionExamples/maui-numericentry-samples) that shows you how to render the Combobox in .NET MAUI.

--- a/MAUI/NumericEntry/Getting-Started.md
+++ b/MAUI/NumericEntry/Getting-Started.md
@@ -269,3 +269,5 @@ private void sfNumericEntry_ValueChanged(object sender, NumericEntryValueChanged
 {% endtabs %}
 
 You can find the complete getting started sample of .NET MAUI from this [link.](https://github.com/SyncfusionExamples/maui-numericentry-samples)
+
+N> You can refer to our [.NET MAUI Numeric Entry](https://www.syncfusion.com/maui-controls/maui-numeric-entry) feature tour page for its groundbreaking feature representations. You can also explore our [.NET MAUI Numeric Entry Example](https://github.com/SyncfusionExamples/maui-numericentry-samples/tree/master/NumericEntryGettingStarted) that shows you how to render the Numeric Entry in .NET MAUI.

--- a/MAUI/NumericEntry/Getting-Started.md
+++ b/MAUI/NumericEntry/Getting-Started.md
@@ -270,4 +270,4 @@ private void sfNumericEntry_ValueChanged(object sender, NumericEntryValueChanged
 
 You can find the complete getting started sample of .NET MAUI from this [link.](https://github.com/SyncfusionExamples/maui-numericentry-samples)
 
-N> You can refer to our [.NET MAUI Numeric Entry](https://www.syncfusion.com/maui-controls/maui-numeric-entry) feature tour page for its groundbreaking feature representations. You can also explore our [.NET MAUI Numeric Entry Example](https://github.com/SyncfusionExamples/maui-numericentry-samples/tree/master/NumericEntryGettingStarted) that shows you how to render the Numeric Entry in .NET MAUI.
+N> You can refer to our [.NET MAUI Numeric Entry](https://www.syncfusion.com/maui-controls/maui-numeric-entry) feature tour page for its groundbreaking feature representations.

--- a/MAUI/NumericEntry/Getting-Started.md
+++ b/MAUI/NumericEntry/Getting-Started.md
@@ -268,4 +268,4 @@ private void sfNumericEntry_ValueChanged(object sender, NumericEntryValueChanged
 {% endhighlight %}
 {% endtabs %}
 
-N> You can refer to our [.NET MAUI Numeric Entry](https://www.syncfusion.com/maui-controls/maui-numeric-entry) feature tour page for its groundbreaking feature representations. You can also explore our [.NET MAUI Combobox Example](https://github.com/SyncfusionExamples/maui-numericentry-samples) that shows you how to render the Combobox in .NET MAUI.
+N> You can refer to our [.NET MAUI Numeric Entry](https://www.syncfusion.com/maui-controls/maui-numeric-entry) feature tour page for its groundbreaking feature representations. You can also explore our [.NET MAUI Numeric Entry Example](https://github.com/SyncfusionExamples/maui-numericentry-samples) that shows you how to render the Numeric Entry in .NET MAUI.


### PR DESCRIPTION
Hi @Girija-Rajendran,

|Title|Description|
|--|--|
|Task Category| .NET MAUI Numeric Entry|
|Content Task Link/Mail Screenshot|![image](https://github.com/syncfusion-content/featuretour-maui/assets/95272306/d0db4266-af52-45ca-9b4c-7c83791e03f3)|
|UX task| NA|
|Interlinkinng PR link| Interlinking -https://github.com/syncfusion-content/maui-docs/pull/1631|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/176405/|
|Excel/SharePoint link|https://syncfusion.sharepoint.com/sites/GH/SEO/SitePages/NET-MAUI-Numeric-Entry---Money-Keywords.aspx|

| Keyword | Volume | Position | Reason for change | Changes Made |
| ---      | ---       | ---     | ---     | ---     |
|.net maui numeric entry|10-100 |3FT|To improve our FT experience |added CSS classes alignment format, images aligned in zigzag form, added documentation & Example links, unwanted space removed. |
|.net maui numeric entry example|0-10 |3FT,4UG|To remove the page from omitted result and improve page experience | demo link added|
|.net maui numeric entry control |0-10 |3FT|To improve our FT experience | improved on page changes|
|formatting in .net maui numeric entry|0-10 |1FT |To remove our FT ranking to 1st position| added CSS classes alignment format, images aligned in zigzag form, added documentation & Example links, unwanted space removed|
|restriction in .net maui numeric entry|0-10 |1FT| To improve our FT experience |added corresponding documentation links, arranged images in zigzag form|

Worked on 17 keywords in the .NET MAUI Numeric Entry and am keeping track of all keyword details in the link below:-
https://syncfusion.sharepoint.com/sites/GH/SEO/SitePages/NET-MAUI-Numeric-Entry---Money-Keywords.aspx

Regards,
Yvone.