### PR TITLE
859492 - Add the HTML tag link for .NET MAUI NavigationDrawer UG documentation.

### DIFF
--- a/maui-toc.html
+++ b/maui-toc.html
@@ -706,6 +706,7 @@
             <li><a href="/maui/NavigationDrawer/Side-Pane-Sizing">Setting Sliding Panel size</a></li>
             <li><a href="/maui/NavigationDrawer/Swipe-Gesture">SwipeGesture</a></li>
             <li><a href="/maui/NavigationDrawer/Toggle-Animations">Setting Toggle Animations</a></li>
+            <li><a href="/maui/NavigationDrawer/Events">Events</a></li>
         </ul>
     </li>
     <li>


### PR DESCRIPTION
Add the HTML tag link for .NET MAUI NavigationDrawer UG documentation.