### PR TITLE
875166-Resolved Unexpected character error in Migration document-(SfPdfViewer)

### DIFF
--- a/MAUI/PDF-Viewer/Migration.md
+++ b/MAUI/PDF-Viewer/Migration.md
@@ -396,7 +396,7 @@ To make migration from [Xamarin SfPdfViewer](https://www.syncfusion.com/xamarin-
 <td>Prints the PDF document.</td>
 </tr>
 <tr>
-<td>{{'[SaveDocument(Boolean)](https://help.syncfusion.com/cr/xamarin/Syncfusion.SfPdfViewer.XForms.SfPdfViewer.html#Syncfusion_SfPdfViewer_XForms_SfPdfViewer_SaveDocument_System_Boolean_)'| markdownify }}</td>
+<td>{{'[SaveDocument(bool flattenForm)](https://help.syncfusion.com/cr/xamarin/Syncfusion.SfPdfViewer.XForms.SfPdfViewer.html#Syncfusion_SfPdfViewer_XForms_SfPdfViewer_SaveDocument_System_Boolean_)'| markdownify }}</td>
 <td>{{'FormField.FlattenOnSave'| markdownify }}</td>
 <td>Specifies whether the form fields should be flattened or not on saving</td>
 </tr>

--- a/MAUI/PDF-Viewer/Migration.md
+++ b/MAUI/PDF-Viewer/Migration.md
@@ -397,7 +397,7 @@ To make migration from [Xamarin SfPdfViewer](https://www.syncfusion.com/xamarin-
 </tr>
 <tr>
 <td>{{'[SaveDocument](https://help.syncfusion.com/cr/xamarin/Syncfusion.SfPdfViewer.XForms.SfPdfViewer.html#Syncfusion_SfPdfViewer_XForms_SfPdfViewer_SaveDocument)'| markdownify }}</td>
-<td>{{`FlattenOnSave`| markdownify }}</td>
+<td>{{'FlattenOnSave'| markdownify }}</td>
 <td>Saves the document and returns the stream.</td>
 </tr>
 </table>

--- a/MAUI/PDF-Viewer/Migration.md
+++ b/MAUI/PDF-Viewer/Migration.md
@@ -396,9 +396,9 @@ To make migration from [Xamarin SfPdfViewer](https://www.syncfusion.com/xamarin-
 <td>Prints the PDF document.</td>
 </tr>
 <tr>
-<td>{{'[SaveDocument](https://help.syncfusion.com/cr/xamarin/Syncfusion.SfPdfViewer.XForms.SfPdfViewer.html#Syncfusion_SfPdfViewer_XForms_SfPdfViewer_SaveDocument)'| markdownify }}</td>
-<td>{{'FlattenOnSave'| markdownify }}</td>
-<td>Saves the document and returns the stream.</td>
+<td>{{'[SaveDocument(Boolean)](https://help.syncfusion.com/cr/xamarin/Syncfusion.SfPdfViewer.XForms.SfPdfViewer.html#Syncfusion_SfPdfViewer_XForms_SfPdfViewer_SaveDocument_System_Boolean_)'| markdownify }}</td>
+<td>{{'FormField.FlattenOnSave'| markdownify }}</td>
+<td>Specifies whether the form fields should be flattened or not on saving</td>
 </tr>
 </table>
 


### PR DESCRIPTION
Task Link : https://dev.azure.com/EssentialStudio/Mobile%20and%20Desktop/_workitems/edit/875166/
Title : Xamarin Migration document content changing
Issue : Unexpected character ` in "{{`FlattenOnSave`| markdownify }}" in maui/PDF-Viewer/Migration.md[0m
Fix : Changed the FlattenOnSave into ( ' ) single quote