### PR TITLE
MAUI-892140 Add Legend Toggle and Stacked Area Marker Support content to UG Documentation

### DIFF
--- a/MAUI/Cartesian-Charts/Area.md
+++ b/MAUI/Cartesian-Charts/Area.md
@@ -203,6 +203,7 @@ AreaSeries series = new AreaSeries()
    YBindingPath = "Percentage",
    ItemsSource = new ViewModel().Data,
    ShowMarkers = true,
+   MarkerSettings = chartMarker
 };
 
 chart.Series.Add(series);

--- a/MAUI/Cartesian-Charts/Area.md
+++ b/MAUI/Cartesian-Charts/Area.md
@@ -14,7 +14,7 @@ keywords: .net maui area chart, .net maui chart area type, area chart customizat
 
 The area chart is rendered by using a collection of line segments connected to form a closed loop area, filled with the specified color. To render a area chart, create an instance of [AreaSeries](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.AreaSeries.html?tabs=tabid-1) and add it to the [Series](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.SfCartesianChart.html#Syncfusion_Maui_Charts_SfCartesianChart_Series) collection property of the chart.
 
-N> The cartesian chart has [Series](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.SfCartesianChart.html#Syncfusion_Maui_Charts_SfCartesianChart_Series) as its default content.
+N> The Cartesian chart has [Series](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.SfCartesianChart.html#Syncfusion_Maui_Charts_SfCartesianChart_Series) as its default content.
 
 {% tabs %}
 

--- a/MAUI/Cartesian-Charts/RangeArea.md
+++ b/MAUI/Cartesian-Charts/RangeArea.md
@@ -162,6 +162,7 @@ RangeAreaSeries series = new RangeAreaSeries()
     Low = "LowValue",
     ItemsSource = new ViewModel().Data,
     ShowMarkers = true,
+    MarkerSettings = chartMarker
 };
 
 chart.Series.Add(series);

--- a/MAUI/Cartesian-Charts/StackedArea.md
+++ b/MAUI/Cartesian-Charts/StackedArea.md
@@ -98,3 +98,103 @@ this.Content = chart;
 {% endtabs %}
 
 ![Stacking Area Chart in .NET MAUI Cartesian Charts.](chart-types-images\net-maui-cartesian-charts-stacked-area-chart.png)
+
+## Enable Marker
+
+A marker, also known as a symbol, is used to determine or highlight the position of the data point. To enable markers in the series, set the [ShowMarkers]() property to `true`.
+
+{% tabs %}
+
+{% highlight xaml %}
+
+<chart:SfCartesianChart>
+    ...
+    <chart:StackingAreaSeries ItemsSource="{Binding StackData}"
+                              XBindingPath="Year"
+                              YBindingPath="Value"
+                              ShowMarkers="True"/>
+    ...
+</chart:SfCartesianChart>
+
+{% endhighlight %}
+
+{% highlight c# %}
+
+SfCartesianChart chart = new SfCartesianChart();
+...
+StackingAreaSeries series = new StackingAreaSeries()
+{
+    ItemsSource = new ViewModel().StackData,
+    XBindingPath = "Year",
+    YBindingPath = "Value",
+    ShowMarkers= true
+};
+...
+chart.Series.Add(series);
+this.Content= chart;
+
+{% endhighlight %}
+
+{% endtabs %}
+
+### Marker customization
+
+In order to change the series markers’ appearance, create an instance of the [MarkerSettings]() property. The following properties are used to customize marker appearance.
+
+* [Type](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_Type), of type `ShapeType`, describes the shape of the series marker. The default value of this property is the [ShapeType.Circle]().
+* [Stroke](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_Stroke), of type `Brush`, indicates the brush used to paint the marker border.
+* [StrokeWidth](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_StrokeWidth), of type `double`, indicates the width of the marker border.
+* [Fill](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_Fill), of type `Brush`, indicates the color of the marker.
+* [Width](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_Width), of type `double`, indicates the width of the marker.
+* [Height](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_Height), of type `double`, indicates the height of the marker.
+
+{% tabs %}
+
+{% highlight xaml %}
+
+<chart:SfCartesianChart>
+    ...
+    <chart:StackingAreaSeries ItemsSource="{Binding StackData}"
+                              XBindingPath="Year"
+                              YBindingPath="Value"
+                              ShowMarkers="True">
+        <chart:StackingAreaSeries.MarkerSettings>
+            <chart:ChartMarkerSettings Type="Diamond"
+                                       Fill="LightBlue"
+                                       Stroke="Blue"
+                                       StrokeWidth="1"
+                                       Height="8"
+                                       Width="8"/>
+        </chart:StackingAreaSeries.MarkerSettings>
+    </chart:StackingAreaSeries>
+    ...
+</chart:SfCartesianChart>
+
+{% endhighlight %}
+
+{% highlight c# %}
+
+SfCartesianChart chart = new SfCartesianChart();
+...
+ChartMarkerSettings chartMarker= new ChartMarkerSettings();
+chartMarker.Type = ShapeType.Diamond;
+chartMarker.Fill = Colors.LightBlue;
+chartMarker.Stroke = Colors.Blue;
+chartMarker.StrokeWidth= 1;
+chartMarker.Height = 8;
+chartMarker.Width = 8;
+
+StackingAreaSeries series = new StackingAreaSeries()
+{
+    ItemsSource = new ViewModel().StackData,
+    XBindingPath = "Year",
+    YBindingPath = "Value",
+    ShowMarkers= true
+};
+...
+chart.Series.Add(series);
+this.Content= chart;
+
+{% endhighlight %}
+
+{% endtabs %}

--- a/MAUI/Cartesian-Charts/StackedArea.md
+++ b/MAUI/Cartesian-Charts/StackedArea.md
@@ -189,7 +189,8 @@ StackingAreaSeries series = new StackingAreaSeries()
     ItemsSource = new ViewModel().StackData,
     XBindingPath = "Year",
     YBindingPath = "Value",
-    ShowMarkers= true
+    ShowMarkers= true,
+    MarkerSettings = chartMarker
 };
 ...
 chart.Series.Add(series);

--- a/MAUI/Cartesian-Charts/StackedArea100.md
+++ b/MAUI/Cartesian-Charts/StackedArea100.md
@@ -192,7 +192,8 @@ StackingArea100Series series = new StackingArea100Series()
     ItemsSource = new ViewModel().StackData,
     XBindingPath = "Year",
     YBindingPath = "Value",
-    ShowMarkers= true
+    ShowMarkers= true,
+    MarkerSettings = chartMarker
 };
 ...
 chart.Series.Add(series);

--- a/MAUI/Cartesian-Charts/StackedArea100.md
+++ b/MAUI/Cartesian-Charts/StackedArea100.md
@@ -101,3 +101,103 @@ this.Content = chart;
 {% endtabs %}
 
 ![Stacking Area 100 Chart in .NET MAUI Cartesian Charts](chart-types-images/net-maui-cartesian-charts-stacked-area-100-chart.png)
+
+## Enable Marker
+
+A marker, also known as a symbol, is used to determine or highlight the position of the data point. To enable markers in the series, set the [ShowMarkers]() property to `true`.
+
+{% tabs %}
+
+{% highlight xaml %}
+
+<chart:SfCartesianChart>
+    ...
+    <chart:StackingArea100Series ItemsSource="{Binding StackData}"
+                                 XBindingPath="Year"
+                                 YBindingPath="Value"
+                                 ShowMarkers="True"/>
+    ...
+</chart:SfCartesianChart>
+
+{% endhighlight %}
+
+{% highlight c# %}
+
+SfCartesianChart chart = new SfCartesianChart();
+...
+StackingArea100Series series = new StackingArea100Series()
+{
+    ItemsSource = new ViewModel().StackData,
+    XBindingPath = "Year",
+    YBindingPath = "Value",
+    ShowMarkers= true
+};
+...
+chart.Series.Add(series);
+this.Content= chart;
+
+{% endhighlight %}
+
+{% endtabs %}
+
+### Marker customization
+
+In order to change the series markers’ appearance, create an instance of the [MarkerSettings]() property. The following properties are used to customize marker appearance.
+
+* [Type](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_Type), of type `ShapeType`, describes the shape of the series marker. The default value of this property is the [ShapeType.Circle]().
+* [Stroke](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_Stroke), of type `Brush`, indicates the brush used to paint the marker border.
+* [StrokeWidth](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_StrokeWidth), of type `double`, indicates the width of the marker border.
+* [Fill](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_Fill), of type `Brush`, indicates the color of the marker.
+* [Width](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_Width), of type `double`, indicates the width of the marker.
+* [Height](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartMarkerSettings.html#Syncfusion_Maui_Charts_ChartMarkerSettings_Height), of type `double`, indicates the height of the marker.
+
+{% tabs %}
+
+{% highlight xaml %}
+
+<chart:SfCartesianChart>
+    ...
+    <chart:StackingArea100Series ItemsSource="{Binding StackData}"
+                                 XBindingPath="Year"
+                                 YBindingPath="Value"
+                                 ShowMarkers="True">
+        <chart:StackingArea100Series.MarkerSettings>
+            <chart:ChartMarkerSettings Type="Diamond"
+                                       Fill="LightBlue"
+                                       Stroke="Blue"
+                                       StrokeWidth="1"
+                                       Height="8"
+                                       Width="8"/>
+        </chart:StackingArea100Series.MarkerSettings>
+    </chart:StackingArea100Series>
+    ...
+</chart:SfCartesianChart>
+
+{% endhighlight %}
+
+{% highlight c# %}
+
+SfCartesianChart chart = new SfCartesianChart();
+...
+ChartMarkerSettings chartMarker= new ChartMarkerSettings();
+chartMarker.Type = ShapeType.Diamond;
+chartMarker.Fill = Colors.LightBlue;
+chartMarker.Stroke = Colors.Blue;
+chartMarker.StrokeWidth= 1;
+chartMarker.Height = 8;
+chartMarker.Width = 8;
+
+StackingArea100Series series = new StackingArea100Series()
+{
+    ItemsSource = new ViewModel().StackData,
+    XBindingPath = "Year",
+    YBindingPath = "Value",
+    ShowMarkers= true
+};
+...
+chart.Series.Add(series);
+this.Content= chart;
+
+{% endhighlight %}
+
+{% endtabs %}

--- a/MAUI/Cartesian-Charts/StepArea.md
+++ b/MAUI/Cartesian-Charts/StepArea.md
@@ -14,7 +14,7 @@ keywords: .net maui step area chart, maui step area chart, .net maui chart step 
 The step area chart displays data that changes over time or across different categories. 
 In a step area chart, the data points are connected by horizontal and vertical lines to create a series of steps. Each step represents a specific time interval or category. The area between the steps is then filled with a color or shading. To render an area chart, create an instance of [StepAreaSeries](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.StepAreaSeries.html), and add it to the [Series](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.SfCartesianChart.html#Syncfusion_Maui_Charts_SfCartesianChart_Series) collection property of the [SfCartesianChart](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.SfCartesianChart.html?tabs=tabid-1). 
 
-N> The cartesian chart has [Series](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.SfCartesianChart.html#Syncfusion_Maui_Charts_SfCartesianChart_Series) as its default content.
+N> The Cartesian chart has [Series](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.SfCartesianChart.html#Syncfusion_Maui_Charts_SfCartesianChart_Series) as its default content.
 
 {% tabs %}
 

--- a/MAUI/Cartesian-Charts/StepArea.md
+++ b/MAUI/Cartesian-Charts/StepArea.md
@@ -152,6 +152,7 @@ StepAreaSeries = new StepAreaSeries()
    YBindingPath = "Value",
    ItemsSource = new ViewModel().Data,
    ShowMarkers = true,
+   MarkerSettings = chartMarker
 };
 
 chart.Series.Add(series);

--- a/MAUI/Cartesian-Charts/migration.md
+++ b/MAUI/Cartesian-Charts/migration.md
@@ -198,7 +198,7 @@ The following table illustrates the API migration for the chart.
 </tr>
 <tr>
 <td>TickPosition</td>
-<td><em>TickPosition</em></td>
+<td>TickPosition</td>
 </tr>
 <tr>
 <td>MaximumLabels</td>
@@ -206,11 +206,11 @@ The following table illustrates the API migration for the chart.
 </tr>
 <tr>
 <td>LabelsIntersectAction</td>
-<td><em>Upcoming</em></td>
+<td>LabelsIntersectAction</td>
 </tr>
 <tr>
 <td>TrackballLabelTemplate</td>
-<td><em>TrackballLabelTemplate</em></td>
+<td>TrackballLabelTemplate</td>
 </tr>
 </table>
 
@@ -870,7 +870,7 @@ chart.ZoomPanBehavior = zooming;
 * Title support for legend. 
 * Support to enable or disable the legend icon visibility.
 * Legend floating support.
-* Event or method to notify the legend click and the creation of a legend item.
+* Event or method to notify when a legend item is clicked.
 
 **Data label**
 

--- a/MAUI/Circular-Charts/migration.md
+++ b/MAUI/Circular-Charts/migration.md
@@ -227,7 +227,7 @@ this.Content = chart;
 </tr>
 <tr>
 <td>ToggleSeriesVisibility</td>
-<td><em>Upcoming</em></td>
+<td>ToggleSeriesVisibility</td>
 </tr>
 <tr>
 <td>OverflowMode</td>
@@ -617,7 +617,7 @@ N> For more information about selection check [here](https://help.syncfusion.com
 * Title support for legend. 
 * Support to enable or disable the legend icon visibility.
 * Legend floating support.
-* Event or method to notify the legend click and the creation of a legend item.
+* Event or method to notify when a legend item is clicked.
 * The ability to show/hide corresponding data points by legend item toggle.
 
 ## Known issue 

--- a/MAUI/Funnel-Charts/Legend.md
+++ b/MAUI/Funnel-Charts/Legend.md
@@ -153,6 +153,45 @@ this.Content = chart;
 
 {% endtabs %}
 
+## Toggle the series visibility
+The visibility of segments in the funnel chart can be controlled by tapping the legend item using the [ToggleSeriesVisibility](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLegend.html?tabs=tabid-1%2Ctabid-3%2Ctabid-7%2Ctabid-12%2Ctabid-5%2Ctabid-10#Syncfusion_Maui_Charts_ChartLegend_ToggleSeriesVisibility) property. The default value of ToggleSeriesVisibility is `false`.
+
+{% tabs %}
+
+{% highlight xaml %}
+
+<chart:SfFunnelChart ItemsSource="{Binding Data}" 
+                     XBindingPath="Name"         
+                     YBindingPath="Value">
+    . . .
+    <chart:SfFunnelChart.Legend>
+        <chart:ChartLegend ToggleSeriesVisibility="True"/>
+    </chart:SfFunnelChart.Legend>
+    . . .
+</chart:SfFunnelChart>
+
+{% endhighlight %}
+
+{% highlight c#}
+
+ChartViewModel viewModel = new();
+
+SfFunnelChart funnelChart = new SfFunnelChart()
+{
+    ItemsSource = viewModel.Data,
+    XBindingPath = "Name",
+    YBindingPath = "Value"
+};
+
+funnelChart.Legend = new ChartLegend()
+{
+    ToggleSeriesVisibility = true
+};
+
+{% endhighlight %}
+
+{% endtabs %}
+
 ## Legend maximum size request
 To set the maximum size request for the legend view, override the [GetMaximumSizeCoefficient](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLegend.html#Syncfusion_Maui_Charts_ChartLegend_GetMaximumSizeCoefficient) protected method in [ChartLegend](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLegend.html) class. The value should be between 0 and 1, representing the maximum size request, not the desired size for the legend items layout.
 

--- a/MAUI/Funnel-Charts/Legend.md
+++ b/MAUI/Funnel-Charts/Legend.md
@@ -10,7 +10,7 @@ keywords: .net maui funnel chart, funnel-chart, chart legend, legend-wrap, legen
 
 # Legend in .NET MAUI Chart (SfFunnelChart)
 
-The [Legend](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartBase.html#Syncfusion_Maui_Charts_ChartBase_Legend) provides a list of data points, helping to identify the corresponding data points in the chart. Here's a detailed guide on how to define and customize the legend in the cartesian chart.
+The [Legend](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartBase.html#Syncfusion_Maui_Charts_ChartBase_Legend) provides a list of data points, helping to identify the corresponding data points in the chart. Here's a detailed guide on how to define and customize the legend in the Cartesian chart.
 
 ## Defining the legend
 
@@ -172,7 +172,7 @@ The visibility of segments in the funnel chart can be controlled by tapping the 
 
 {% endhighlight %}
 
-{% highlight c#}
+{% highlight c# }
 
 ChartViewModel viewModel = new();
 

--- a/MAUI/Funnel-Charts/Legend.md
+++ b/MAUI/Funnel-Charts/Legend.md
@@ -10,7 +10,7 @@ keywords: .net maui funnel chart, funnel-chart, chart legend, legend-wrap, legen
 
 # Legend in .NET MAUI Chart (SfFunnelChart)
 
-The [Legend](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartBase.html#Syncfusion_Maui_Charts_ChartBase_Legend) provides a list of data points, helping to identify the corresponding data points in the chart. Here's a detailed guide on how to define and customize the legend in the Cartesian chart.
+The [Legend](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartBase.html#Syncfusion_Maui_Charts_ChartBase_Legend) provides a list of data points, helping to identify the corresponding data points in the chart. Here's a detailed guide on how to define and customize the legend in the funnel chart.
 
 ## Defining the legend
 

--- a/MAUI/Funnel-Charts/Legend.md
+++ b/MAUI/Funnel-Charts/Legend.md
@@ -172,7 +172,7 @@ The visibility of segments in the funnel chart can be controlled by tapping the 
 
 {% endhighlight %}
 
-{% highlight c# }
+{% highlight c# %}
 
 ChartViewModel viewModel = new();
 

--- a/MAUI/Funnel-Charts/migration.md
+++ b/MAUI/Funnel-Charts/migration.md
@@ -224,7 +224,7 @@ this.Content = chart;
 </tr>
 <tr>
 <td>ToggleSeriesVisibility</td>
-<td><em>Upcoming</em></td>
+<td>ToggleSeriesVisibility</td>
 </tr>
 <tr>
 <td>OverflowMode</td>
@@ -600,7 +600,7 @@ chart.SelectionBehavior = selection;
 * Title support for legend. 
 * Support to enable or disable the legend icon visibility.
 * Legend floating support.
-* Event or method to notify the legend click and the creation of a legend item.
+* Event or method to notify when a legend item is clicked.
 * The ability to show/hide corresponding data points by legend item toggle.
 
 **Data label**

--- a/MAUI/Polar-Charts/PolarArea.md
+++ b/MAUI/Polar-Charts/PolarArea.md
@@ -199,7 +199,8 @@ PolarAreaSeries series = new PolarAreaSeries()
     ItemsSource = new ViewModel().PlantDetails,
     XBindingPath = "Direction",
     YBindingPath = "Tree",
-    ShowMarkers = true
+    ShowMarkers = true,
+    MarkerSettings = chartMarker
 };
 
 ChartMarkerSettings chartMarker= new ChartMarkerSettings();

--- a/MAUI/Polar-Charts/PolarLine.md
+++ b/MAUI/Polar-Charts/PolarLine.md
@@ -199,7 +199,8 @@ PolarLineSeries series = new PolarLineSeries()
     ItemsSource = new ViewModel().PlantDetails,
     XBindingPath = "Direction",
     YBindingPath = "Tree",
-    ShowMarkers = true
+    ShowMarkers = true,
+    MarkerSettings = chartMarker
  };
 
 ChartMarkerSettings chartMarker= new ChartMarkerSettings();

--- a/MAUI/Polar-Charts/migration.md
+++ b/MAUI/Polar-Charts/migration.md
@@ -156,7 +156,7 @@ The following table illustrates the API migration for the chart.
 </tr>
 <tr>
 <td>TickPosition</td>
-<td><em>TickPosition</em></td>
+<td>TickPosition</td>
 </tr>
 <tr>
 <td>MaximumLabels</td>
@@ -646,7 +646,7 @@ chart.TooltipBehavior = tooltip;
 * Title support for legend. 
 * Support to enable or disable the legend icon visibility.
 * Legend floating support.
-* Event or method to notify the legend click and the creation of a legend item.
+* Event or method to notify when a legend item is clicked.
 
 ## Known issue 
 

--- a/MAUI/Pyramid-Charts/Legend.md
+++ b/MAUI/Pyramid-Charts/Legend.md
@@ -156,6 +156,43 @@ this.Content = chart;
 
 {% endtabs %}
 
+## Toggle the series visibility
+The visibility of segments in the pyramid chart can be controlled by tapping the legend item using the [ToggleSeriesVisibility](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLegend.html?tabs=tabid-1%2Ctabid-3%2Ctabid-7%2Ctabid-12%2Ctabid-5%2Ctabid-10#Syncfusion_Maui_Charts_ChartLegend_ToggleSeriesVisibility) property. The default value of ToggleSeriesVisibility is `false`.
+
+{% tabs %}
+
+{% highlight xaml %}
+
+<chart:SfPyramidChart ItemsSource="{Binding Data}" 
+                      XBindingPath="Name"         
+                      YBindingPath="Value">
+    . . .
+    <chart:SfPyramidChart.Legend>
+        <chart:ChartLegend ToggleSeriesVisibility="True"/>
+    </chart:SfPyramidChart.Legend>
+    . . .
+</chart:SfPyramidChart>
+
+{% endhighlight %}
+
+{% highlight c# %}
+
+SfPyramidChart pyramidChart = new SfPyramidChart()
+{
+    ItemsSource = viewModel.Data,
+    XBindingPath = "Name",
+    YBindingPath = "Value"
+};
+
+pyramidChart.Legend = new ChartLegend()
+{
+    ToggleSeriesVisibility = true
+};
+
+{% endhighlight %}
+
+{% tabs %}
+
 ## Legend maximum size request
 To set the maximum size request for the legend view, override the [GetMaximumSizeCoefficient](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLegend.html#Syncfusion_Maui_Charts_ChartLegend_GetMaximumSizeCoefficient) protected method in [ChartLegend](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Charts.ChartLegend.html) class. The value should be between 0 and 1, representing the maximum size request, not the desired size for the legend items layout.
 

--- a/MAUI/Pyramid-Charts/migration.md
+++ b/MAUI/Pyramid-Charts/migration.md
@@ -224,7 +224,7 @@ this.Content = chart;
 </tr>
 <tr>
 <td>ToggleSeriesVisibility</td>
-<td><em>Upcoming</em></td>
+<td>ToggleSeriesVisibility</td>
 </tr>
 <tr>
 <td>OverflowMode</td>
@@ -600,7 +600,7 @@ chart.SelectionBehavior = selection;
 * Title support for legend. 
 * Support to enable or disable the legend icon visibility.
 * Legend floating support.
-* Event or method to notify the legend click and the creation of a legend item.
+* Event or method to notify when a legend item is clicked.
 * The ability to show/hide corresponding data points by legend item toggle.
 
 **Data label**


### PR DESCRIPTION
This PR updates the User Guide (UG) to include new content regarding the following features:

•	**Legend Toggle Support**: Added instructions and examples on how to use the legend toggle feature in the following charts, allowing users to easily show or hide legends as needed.
                     o	SfPyramidChart
                     o	SfFunnelChart
•	**Marker Support**: Included details on how to utilize marker support for the following charts, enabling users to add and customize markers for better data visualization.
                     o	Stacked Area Chart
                     o	Stacked Area 100 Chart

These additions aim to enhance the documentation and provide clearer guidance on leveraging these features effectively.

Changes Made:
•	Updated UG sections related to chart customization.
•	Added examples and usage scenarios for legend toggle and marker features.