### PR TITLE
898689 - Update the toolbar names in MAUI PDF Viewer

### DIFF
--- a/MAUI/PDF-Viewer/Toolbar.md
+++ b/MAUI/PDF-Viewer/Toolbar.md
@@ -109,14 +109,6 @@ The names of these toolbars and its description are listed in the following sect
 <td>StickyNoteIconsToolbar</td>
 <td>The toolbar for editing sticky note icons appears at the bottom of the mobile PDF viewer.</td>
 </tr>
-<tr>
-<td>SearchToolbar</td>
-<td>The toolbar for text search appears at the top of the mobile PDF viewer.</td>
-</tr>
-<tr>
-<td>MoreOptionToolbar</td>
-<td>The toolbar for more options appears at the top of the mobile PDF viewer.</td>
-</tr>
 </table>
 
 ### Desktop toolbar names 


### PR DESCRIPTION
I have removed the following toolbar names
**Reason** : Below mentioned toolbar are dropdown toolbar of TopToolbar's icon and it is also not given the toolbar list for desktop. For Mobile platform 20 toolbars are listed and Desktop has 17 toolbars are listed. I have cross checked all the toolbar with source


| Toolbar Name        | Description                                                     |
|---------------------|-----------------------------------------------------------------|
| SearchToolbar       | The toolbar for text search appears at the top of the mobile PDF viewer. |
| MoreOptionToolbar   | The toolbar for more options appears at the top of the mobile PDF viewer. |

