### PR TITLE
Resolve Liquid syntax error in Badge-View/Getting-Started.md

### DIFF
--- a/MAUI/Badge-View/Getting-Started.md
+++ b/MAUI/Badge-View/Getting-Started.md
@@ -94,8 +94,6 @@ namespace BadgeViewMauiSample
         <badgeView:SfBadgeView />
     </Grid>
 </ContentPage>
-	
-{% endhighlight %}
 
 {% endhighlight %}
 


### PR DESCRIPTION
Resolve Liquid syntax error in Badge-View/Getting-Started.md