### PR TITLE
Fixed the exception in MAUI PDF Viewer Documents

### DIFF
--- a/MAUI/PDF-Viewer/Magnification.md
+++ b/MAUI/PDF-Viewer/Magnification.md
@@ -5,7 +5,7 @@ description: Learn here all about magnification feature in Syncfusion .NET MAUI 
 platform: MAUI
 control: SfPdfViewer
 documentation: ug
-keywords: keywords: .net maui pdf viewer, .net maui view pdf, pdf viewer in .net maui, .net maui open pdf, maui pdf viewer, maui pdf view.
+keywords: .net maui pdf viewer, .net maui view pdf, pdf viewer in .net maui, .net maui open pdf, maui pdf viewer, maui pdf view.
 ---
 
 # Magnification .NET MAUI PDF Viewer (SfPdfViewer)

--- a/MAUI/PDF-Viewer/Migration.md
+++ b/MAUI/PDF-Viewer/Migration.md
@@ -5,7 +5,7 @@ description: Learn here all about migrating from Syncfusion Xamarin SfPdfViewer 
 platform: MAUI
 control: SfPdfViewer
 documentation: ug
-keywords: keywords: .net maui pdf viewer, .net maui view pdf, pdf viewer in .net maui, .net maui open pdf, maui pdf viewer, maui pdf view.
+keywords: .net maui pdf viewer, .net maui view pdf, pdf viewer in .net maui, .net maui open pdf, maui pdf viewer, maui pdf view.
 ---
 
 # Migrate from Xamarin.Forms SfPdfViewer to .NET MAUI SfPdfViewer


### PR DESCRIPTION
Fixed the exception in MAUI PDF Viewer Documents
Change 1 : Removed the keyword in migration.md and magnification.md files
Reason : Exception in migration.md and magnification.md files 