### PR TITLE
931298 - Update the missing keys in the theme UG

### DIFF
--- a/MAUI/Themes/Keys.md
+++ b/MAUI/Themes/Keys.md
@@ -10629,6 +10629,30 @@ This page lists the keys for each control and the element to which it is mapped 
             <br/>
         </td>
     </tr>   
+     <tr>
+        <td>
+          SfPdfViewerControlBackgroundColor
+            <br/>
+            <br/>
+        </td> 
+        <td>
+           Background color of the SfPdfViewer control.
+            <br/>
+            <br/>
+        </td>
+    </tr>   
+     <tr>
+        <td>
+          SfPdfViewerLoadingIndicatorColor
+            <br/>
+            <br/>
+        </td> 
+        <td>
+            Color of the loading / busy indicator in the SfPdfViewer.
+            <br/>
+            <br/>
+        </td>
+    </tr>   
 </table>
 
 ## SfPicker

--- a/MAUI/Themes/Keys.md
+++ b/MAUI/Themes/Keys.md
@@ -10648,7 +10648,7 @@ This page lists the keys for each control and the element to which it is mapped 
             <br/>
         </td> 
         <td>
-            Color of the loading / busy indicator in the SfPdfViewer.
+            Color of the document loading and page loading busy indicator in the SfPdfViewer.
             <br/>
             <br/>
         </td>

--- a/MAUI/Themes/Keys.md
+++ b/MAUI/Themes/Keys.md
@@ -10636,7 +10636,7 @@ This page lists the keys for each control and the element to which it is mapped 
             <br/>
         </td> 
         <td>
-           Background color of the SfPdfViewer control.
+           Background color of the SfPdfViewer.
             <br/>
             <br/>
         </td>


### PR DESCRIPTION
Updated the missing themes key in the keys.md file

- SfPdfViewerControlBackgroundColor 
- SfPdfViewerLoadingIndicatorColor