### PR TITLE
SEO-199937--.-NET-MAUI-DataForm--Missing-H1

### DIFF
--- a/MAUI/DataForm/accessibility.md
+++ b/MAUI/DataForm/accessibility.md
@@ -7,7 +7,7 @@ control: SfDataForm
 documentation: ug
 ---
 
-## Accessibility in .NET MAUI DataForm (SfDataForm)
+# Accessibility in .NET MAUI DataForm (SfDataForm)
 
 Accessibility support in `DataForm` is designed to provide voice descriptions of their field name, editor text, and validation text.
 


### PR DESCRIPTION
Title | Description
-- | --
|Task Category | Site Audit Work- Missing H1|
|Content Task Link/Mail Screenshot |NA|
|Hotfix | |
|Ticket/Task link | https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/199937|
|Work link | https://syncfusion.sharepoint.com/:x:/r/sites/GH/_layouts/15/Doc.aspx?sourcedoc=%7B3cf1c3df-fa53-4ea4-8f74-28a05da09714%7D&action=edit&wdinitialsession=e033b7e1-ee0e-17dc-9ccc-7e31c7f249a2&wdrldsc=2&wdrldc=1&wdrldr=ReloadInEditMode%2CTransitionNonMetro%2COnSaveAsWebMet|

Changes Made | Reason for change |
|-- | -- |
| Worked on Missing | In SEO a page should have one H1 title|