### PR TITLE
MAUI SfImageEditor UG Correction.

### DIFF
--- a/MAUI/ImageEditor/toolbar-customization.md
+++ b/MAUI/ImageEditor/toolbar-customization.md
@@ -478,7 +478,7 @@ SfImageEditor imageEditor = new SfImageEditor();
 imageEditor.Source = ImageSource.FromFile("image.png");
 imageEditor.AutoGenerateToolbarItems = false;
 ImageEditorToolbar editorToolbar = new ();
-editorToolbar.Orientaion = ToolbarOrientation.Vertical;
+editorToolbar.Orientation = ToolbarOrientation.Vertical;
 editorToolbar.Position = ToolbarPosition.End;
 editorToolbar.ToolbarItems = new List<IImageEditorToolbarItem>()
 {
@@ -539,7 +539,7 @@ For example, set the toolbar to a vertical orientation:
 SfImageEditor imageEditor = new SfImageEditor();
 imageEditor.Source = ImageSource.FromFile("image.png");
 ImageEditorToolbar footerToolbar = imageEditor.Toolbars[1];
-footerToolbar.Orientaion = ToolbarOrientation.Vertical;
+footerToolbar.Orientation = ToolbarOrientation.Vertical;
     
 {% endhighlight %}
 


### PR DESCRIPTION
Previously the API name `Orientation` was misspelled as `Orientaion` in the UG. Now changed it to the correct name `Orientation`.