### PR TITLE
Corrected the Datatemplateselector heading format for the SfChip.

### DIFF
--- a/maui-toc.html
+++ b/maui-toc.html
@@ -439,7 +439,7 @@
             <li><a href="/maui/Chips/Populating-Items">Populating Items</a></li>
             <li><a href="/maui/Chips/Chips-Types">Chips Types</a></li>
             <li><a href="/maui/Chips/Customization">Customization</a></li>
-            <li><a href="/maui/Chips/Datatemplateselector">Datatemplateselector</a></li>
+            <li><a href="/maui/Chips/Datatemplateselector">Data Template Selector</a></li>
             <li><a href="/maui/Chips/Events">Events</a></li>
             <li>
                 How To


### PR DESCRIPTION
Hi Team,

For the SfChip, the header format "Datatemplateselector" was changed to "Data Template Selector".