### PR TITLE
SEO-202684-Maui-popup-Popup-Size-description too short

### DIFF
--- a/MAUI/Popup/popup-size.md
+++ b/MAUI/Popup/popup-size.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Popup Size in .NET MAUI Popup control | Syncfusion
-description: Learn all about Popup Size support in the Syncfusion .NET MAUI Popup (SfPopup) control and more.
+description: Checkout and Learn all about Popup Size support in the Syncfusion .NET MAUI Popup (SfPopup) control and more.
 platform: MAUI
 control: SfPopup
 documentation: ug

--- a/MAUI/Popup/popup-size.md
+++ b/MAUI/Popup/popup-size.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Popup Size in .NET MAUI Popup control | Syncfusion
-description: Checkout and Learn all about Popup Size support in the Syncfusion .NET MAUI Popup (SfPopup) control and more.
+description: Checkout and learn here all about Popup Size support in the Syncfusion .NET MAUI Popup (SfPopup) control and more.
 platform: MAUI
 control: SfPopup
 documentation: ug


### PR DESCRIPTION
@MallikaRK 

|Title|Description|
|--|--|
|Task Category|Bing report-Meta description too short|
|Content Task Link/Mail Screenshot| NA|
|UX task| NA|
|Hotfix PR|https://github.com/syncfusion-content/maui-docs/pull/3344 |
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/202684|
|Excel/SharePoint link||

|Changes made|Reason for changes|
|--|--|
|Adding character in the description count |  To get the right description character count from 100-160 |     



Regards,
Hillary