### PR TITLE
955746 - Removed the OpenText Button in Picker

### DIFF
--- a/MAUI/Picker/picker-mode.md
+++ b/MAUI/Picker/picker-mode.md
@@ -175,6 +175,7 @@ SfPicker allows the display of the Popup to render at any desired size by settin
     <picker:SfPicker 
             x:Name="picker"
             Mode="Dialog"
+            IsOpen="True"
             RelativePosition="AlignToRightOf"
             PopupWidth="200"
             PopupHeight="440">
@@ -191,14 +192,6 @@ SfPicker allows the display of the Popup to render at any desired size by settin
             <picker:PickerFooterView  Height="40"/>
         </picker:SfPicker.FooterView>
     </picker:SfPicker>
-    <Button Text="Open Text"
-            x:Name="pickerButton"
-            Clicked="pickerButton_Clicked"
-            HorizontalOptions="Center"
-            VerticalOptions="Center"
-            HeightRequest="40"
-            WidthRequest="150">
-    </Button>
 </Grid>
 
 {% endhighlight %}


### PR DESCRIPTION
Description:
Added WebPage of the UG Document for PopupSize support for the Picker Controls(SfPicker, SfDatePicker, SfDateTimePicker and SfTimePicker) and SfCalendar. Removed the open text button in the picker control.
Related PR:
Picker - https://github.com/essential-studio/maui-picker/pull/393
Calendar - https://github.com/essential-studio/maui-calendar/pull/484