### PR TITLE
Seo-203714-Maui-H1tag-missing-Hotfix 

### DIFF
--- a/MAUI/Scheduler/accessibility.md
+++ b/MAUI/Scheduler/accessibility.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Accessibility in .NET MAUI SfScheduler control | Syncfusion<sup>&reg;</sup>
+title: Accessibility in .NET MAUI SfScheduler control | Syncfusion
 description: Learn here about Accessibility support with the Syncfusion<sup>&reg;</sup> .NET MAUI Scheduler (SfScheduler) control, its elements, and more.
 platform: maui
 control: SfScheduler
 documentation: ug
 ---
 
-## Accessibility Support in .NET MAUI Scheduler (SfScheduler)
+# Accessibility Support in .NET MAUI Scheduler (SfScheduler)
 
 Accessibility support in `SfScheduler` is designed to provide voice descriptions of scheduler elements and scheduled events.
 


### PR DESCRIPTION
Hi @MallikaRK

Title | Description
-- | --
|Task Category |H1 tag missing|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/204026/|
|Share point|[Share point](https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7B425BC1DA-899F-43C9-83EC-59BDC2E6D2D3%7D&file=Bing%20Issues%20-%20SEO.xlsx&action=default&mobileredirect=true)|



Changes Made | Reason for change |
|-- | -- |
|Change h1 tag | One page should have only one H1 tag as per SEO rules, so I changed it.  | 




Regards, 
Asha