### PR TITLE
SEO-204825-Maui-H1tag-missing-Hotfix 

### DIFF
--- a/MAUI/Scheduler/accessibility.md
+++ b/MAUI/Scheduler/accessibility.md
@@ -7,7 +7,7 @@ control: SfScheduler
 documentation: ug
 ---
 
-## Accessibility Support in .NET MAUI Scheduler (SfScheduler)
+# Accessibility Support in .NET MAUI Scheduler (SfScheduler)
 
 Accessibility support in `SfScheduler` is designed to provide voice descriptions of scheduler elements and scheduled events.
 


### PR DESCRIPTION
Hi @MallikaRK 

Title | Description
-- | --
|Task Category |H1 tag missing|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/204825/|
|Share point| [share point](https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7BB8ADF1C8-2C7B-4694-B521-1AEC03ECA949%7D&file=help%20syncfusion.xlsx&action=default&mobileredirect=true)|



Changes Made | Reason for change |
|-- | -- |
|Change h1 tag | One page should have only one H1 tag as per SEO rules, so I changed it. |

Regards, 
Asha