### PR TITLE
SEO-204825-Maui-Description-Too-Short-Hotfix

### DIFF
--- a/MAUI/Avatar-view/Getting-Started.md
+++ b/MAUI/Avatar-view/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Getting Started with Syncfusion® .NET MAUI Avatar View
-description: Learn how to initialize and use the .NET MAUI Avatar View control in a simple way.
+description: Check out and learn here all about how to initialize and use the .NET MAUI Avatar View control in a simple way.
 platform: MAUI
 control: SfAvatarView
 documentation: UG

--- a/MAUI/Common/migration.md
+++ b/MAUI/Common/migration.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Migrating from Xamarin to .NET MAUI | Syncfusion® 
-description: Basic overview of the available .NET MAUI components and their Xamarin equivalents on Syncfusion®.
+description: Check out and learn here all about a basic overview of the available .NET MAUI components and their Xamarin equivalents on Syncfusion®.
 platform: MAUI
 control: Essential Studio®
 documentation: UG

--- a/MAUI/Popup/popup-size.md
+++ b/MAUI/Popup/popup-size.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Popup Size in .NET MAUI Popup control | Syncfusion
-description: Learn all about Popup Size support in the Syncfusion .NET MAUI Popup (SfPopup) control and more.
+description: Check out and learn here all about popup size support in the Syncfusion .NET MAUI Popup (SfPopup) control and more.
 platform: MAUI
 control: SfPopup
 documentation: ug


### PR DESCRIPTION
Hi @MallikaRK 

Title | Description
-- | --
|Task Category |Description too short|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/204825/|
|Share point| [share point](https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7BB8ADF1C8-2C7B-4694-B521-1AEC03ECA949%7D&file=help%20syncfusion.xlsx&action=default&mobileredirect=true)|



Changes Made | Reason for change |
|-- | -- |
|Meta description| Meta description was too short. SEO rule says it should be 100+ characters, so I changed it.|



Regards, 
Asha