### PR TITLE
seo-205214-Maui-H1-tag-Missing-hotfix

### DIFF
--- a/MAUI/Scheduler/accessibility.md
+++ b/MAUI/Scheduler/accessibility.md
@@ -7,7 +7,7 @@ control: SfScheduler
 documentation: ug
 ---
 
-## Accessibility Support in .NET MAUI Scheduler (SfScheduler)
+# Accessibility Support in .NET MAUI Scheduler (SfScheduler)
 
 Accessibility support in `SfScheduler` is designed to provide voice descriptions of scheduler elements and scheduled events.
 


### PR DESCRIPTION
Hi @MallikaRK 

Title | Description
-- | --
|Task Category |H1 Tag Missing|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/205214/|
|Share point | [Share point](https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7B13A50D72-C3C5-4635-90F2-E36DE3A8B07C%7D&file=help%20syncfusion.xlsx&action=default&mobileredirect=true)|



Changes Made | Reason for change |
|-- | -- |
|Change h1 tag | One page should have only one H1 tag as per SEO rules, so I changed it. |




Regards, 
Asha