### PR TITLE
972286 - Update the missing API in the migration document

### DIFF
--- a/MAUI/PDF-Viewer/Migration.md
+++ b/MAUI/PDF-Viewer/Migration.md
@@ -232,6 +232,18 @@ To make migration from [Xamarin SfPdfViewer](https://www.syncfusion.com/xamarin-
   <td>{{'[ShowToolbars](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.PdfViewer.SfPdfViewer.html#Syncfusion_Maui_PdfViewer_SfPdfViewer_ShowToolbars)'| markdownify}}</td> 
   <td>Backing store for the ShowToolbars property.</td>
 </tr>
+<tr>
+  <td>{{'[AnnotationMode.HandwrittenSignature](https://help.syncfusion.com/cr/xamarin/Syncfusion.SfPdfViewer.XForms.AnnotationMode.html#Syncfusion_SfPdfViewer_XForms_AnnotationMode_HandwrittenSignature)'| markdownify}}</td> 
+  <td>{{'[AnnotationMode.Signature](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.PdfViewer.AnnotationMode.html#Syncfusion_Maui_PdfViewer_AnnotationMode_Signature)'| markdownify}}</td> 
+  <td>This will display the signature dialog, allowing the user to create a signature. The created signature can then be added at the tapped location in the PDF Viewer.</td>
+</tr>
+<tr>
+  <td>{{'[AnnotationSettings.HandwrittenSignature](https://help.syncfusion.com/cr/xamarin/Syncfusion.SfPdfViewer.XForms.AnnotationSettings.html#Syncfusion_SfPdfViewer_XForms_AnnotationSettings_HandwrittenSignature)'| markdownify}}</td> 
+  <td>API Unavailable</td> 
+  <td>There is currently no API available in .NET MAUI PDF Viewer for configuring common settings specific to handwritten signatures. However, you can add a handwritten signature by programmatically creating an ink annotation and setting its [IsSignature](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.PdfViewer.InkAnnotation.html#Syncfusion_Maui_PdfViewer_InkAnnotation_IsSignature) property to true.
+
+For detailed instructions on how to add a signature programmatically, please refer to the user guide: [Add a handwritten signature](https://help.syncfusion.com/maui/pdf-viewer/signature#add-a-handwritten-signature).</td>
+</tr>
 </table>
 
 ## Events
@@ -351,14 +363,12 @@ private void PdfViewer_PropertyChanged(object? sender, PropertyChangedEventArgs 
 </tr>
 <tr>
 <td>
-<div>{{'[ExportAsImageAsync](https://help.syncfusion.com/cr/xamarin/Syncfusion.SfPdfViewer.XForms.SfPdfViewer.html#Syncfusion_SfPdfViewer_XForms_SfPdfViewer_ExportAsImageAsync_System_Int32_System_Int32_System_Single_System_Threading_CancellationToken_)'| markdownify }}</div>
-
+{{'[DocumentSaveInitiated](https://help.syncfusion.com/cr/xamarin/Syncfusion.SfPdfViewer.XForms.SfPdfViewer.html#Syncfusion_SfPdfViewer_XForms_SfPdfViewer_DocumentSaveInitiated)'| markdownify }}
 </td>
 <td>API Unavailable</td>
-<td>In .NET MAUI PDF Viewer,  there is no support for exporting PDF as images. However, you can use the Syncfusion PDF to Image Converter library to convert PDF documents into images. 
-For detailed implementation guidance, please refer to the following API documentation:
-{{'[PdfToImageConverter](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.PdfToImageConverter.PdfToImageConverter.html)'| markdownify }}
+<td> In Xamarin, clicking the Save button in the built-in toolbar raises the DocumentSaveInitiated event. However, in .NET MAUI, a Save button is not provided in the built-in toolbar, so the DocumentSaveInitiated event is not available. To save documents from the PDF viewer in .NET MAUI, you can use the [SaveDocument](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.PdfViewer.SfPdfViewer.html#Syncfusion_Maui_PdfViewer_SfPdfViewer_SaveDocument_System_IO_Stream_) method. The PdfViewer control exposes this method as an API, which can be easily integrated into your application. For more details on using the SaveDocument method, refer to the relevant UG Documentation [Save a Document](https://help.syncfusion.com/maui/pdf-viewer/save-a-document).
 
+In .NET MAUI's PdfViewer, if you need to add a Save button to the built-in toolbar, you can do so by customizing the toolbar items. Refer to the [Customize toolbar items user guide](https://help.syncfusion.com/maui/pdf-viewer/toolbar#customize-toolbar-items) for instructions on adding a custom Save button.
 </td>
 </tr>
 </table>
@@ -463,6 +473,18 @@ For detailed implementation guidance, please refer to the following API document
 <td>{{'[SaveDocument(bool flattenForm)](https://help.syncfusion.com/cr/xamarin/Syncfusion.SfPdfViewer.XForms.SfPdfViewer.html#Syncfusion_SfPdfViewer_XForms_SfPdfViewer_SaveDocument_System_Boolean_)'| markdownify }}</td>
 <td>{{'[FormField.FlattenOnSave](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.PdfViewer.FormField.html#Syncfusion_Maui_PdfViewer_FormField_FlattenOnSave)'| markdownify }}</td>
 <td>Specifies whether the form fields should be flattened or not on saving.</td>
+</tr>
+<tr>
+<td>
+<div>{{'[ExportAsImageAsync](https://help.syncfusion.com/cr/xamarin/Syncfusion.SfPdfViewer.XForms.SfPdfViewer.html#Syncfusion_SfPdfViewer_XForms_SfPdfViewer_ExportAsImageAsync_System_Int32_System_Int32_System_Single_System_Threading_CancellationToken_)'| markdownify }}</div>
+
+</td>
+<td>API Unavailable</td>
+<td>In .NET MAUI PDF Viewer,  there is no support for exporting PDF as images. However, you can use the Syncfusion PDF to Image Converter library to convert PDF documents into images. 
+For detailed implementation guidance, please refer to the following API documentation:
+{{'[PdfToImageConverter](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.PdfToImageConverter.PdfToImageConverter.html)'| markdownify }}
+
+</td>
 </tr>
 </table>
 

--- a/MAUI/PDF-Viewer/Migration.md
+++ b/MAUI/PDF-Viewer/Migration.md
@@ -198,6 +198,11 @@ To make migration from [Xamarin SfPdfViewer](https://www.syncfusion.com/xamarin-
 <td>Gets or sets the default settings for stamp annotations.</td>
 </tr>
 <tr>
+  <td>{{'[AnnotationMode.HandwrittenSignature](https://help.syncfusion.com/cr/xamarin/Syncfusion.SfPdfViewer.XForms.AnnotationMode.html#Syncfusion_SfPdfViewer_XForms_AnnotationMode_HandwrittenSignature)'| markdownify}}</td> 
+  <td>{{'[AnnotationMode.Signature](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.PdfViewer.AnnotationMode.html#Syncfusion_Maui_PdfViewer_AnnotationMode_Signature)'| markdownify}}</td> 
+  <td>This will display the signature dialog, allowing the user to create a signature. The created signature can then be added at the tapped location in the PDF Viewer.</td>
+</tr>
+<tr>
 <td>{{'[Selector](https://help.syncfusion.com/cr/xamarin/Syncfusion.SfPdfViewer.XForms.AnnotationSettings.html#Syncfusion_SfPdfViewer_XForms_AnnotationSettings_Selector)'| markdownify}}</td>
 <td>{{'[AnnotationSettings.Selector](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.PdfViewer.AnnotationSettings.html#Syncfusion_Maui_PdfViewer_AnnotationSettings_Selector)'| markdownify}}</td>
 <td>Gets or sets the default settings for the annotation selector.</td>
@@ -233,16 +238,9 @@ To make migration from [Xamarin SfPdfViewer](https://www.syncfusion.com/xamarin-
   <td>Backing store for the ShowToolbars property.</td>
 </tr>
 <tr>
-  <td>{{'[AnnotationMode.HandwrittenSignature](https://help.syncfusion.com/cr/xamarin/Syncfusion.SfPdfViewer.XForms.AnnotationMode.html#Syncfusion_SfPdfViewer_XForms_AnnotationMode_HandwrittenSignature)'| markdownify}}</td> 
-  <td>{{'[AnnotationMode.Signature](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.PdfViewer.AnnotationMode.html#Syncfusion_Maui_PdfViewer_AnnotationMode_Signature)'| markdownify}}</td> 
-  <td>This will display the signature dialog, allowing the user to create a signature. The created signature can then be added at the tapped location in the PDF Viewer.</td>
-</tr>
-<tr>
   <td>{{'[AnnotationSettings.HandwrittenSignature](https://help.syncfusion.com/cr/xamarin/Syncfusion.SfPdfViewer.XForms.AnnotationSettings.html#Syncfusion_SfPdfViewer_XForms_AnnotationSettings_HandwrittenSignature)'| markdownify}}</td> 
   <td>API Unavailable</td> 
-  <td>There is currently no API available in .NET MAUI PDF Viewer for configuring common settings specific to handwritten signatures. However, you can add a handwritten signature by programmatically creating an ink annotation and setting its [IsSignature](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.PdfViewer.InkAnnotation.html#Syncfusion_Maui_PdfViewer_InkAnnotation_IsSignature) property to true.
-
-For detailed instructions on how to add a signature programmatically, please refer to the user guide: [Add a handwritten signature](https://help.syncfusion.com/maui/pdf-viewer/signature#add-a-handwritten-signature).</td>
+  <td>In .NET MAUI PDF Viewer, there is no API to configure common settings for handwritten signatures. However, you can achieve this by handling the [SignatureCreated](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.PdfViewer.SfPdfViewer.html#Syncfusion_Maui_PdfViewer_SfPdfViewer_SignatureCreated) event, which allows you to access and customize each handwritten signature when it is created using the built-in signature dialog.</td>
 </tr>
 </table>
 
@@ -366,9 +364,9 @@ private void PdfViewer_PropertyChanged(object? sender, PropertyChangedEventArgs 
 {{'[DocumentSaveInitiated](https://help.syncfusion.com/cr/xamarin/Syncfusion.SfPdfViewer.XForms.SfPdfViewer.html#Syncfusion_SfPdfViewer_XForms_SfPdfViewer_DocumentSaveInitiated)'| markdownify }}
 </td>
 <td>API Unavailable</td>
-<td> In Xamarin, clicking the Save button in the built-in toolbar raises the DocumentSaveInitiated event. However, in .NET MAUI, a Save button is not provided in the built-in toolbar, so the DocumentSaveInitiated event is not available. To save documents from the PDF viewer in .NET MAUI, you can use the [SaveDocument](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.PdfViewer.SfPdfViewer.html#Syncfusion_Maui_PdfViewer_SfPdfViewer_SaveDocument_System_IO_Stream_) method. The PdfViewer control exposes this method as an API, which can be easily integrated into your application. For more details on using the SaveDocument method, refer to the relevant UG Documentation [Save a Document](https://help.syncfusion.com/maui/pdf-viewer/save-a-document).
+<td> In Xamarin, clicking the Save button in the built-in toolbar raises the [DocumentSaveInitiated](https://help.syncfusion.com/cr/xamarin/Syncfusion.SfPdfViewer.XForms.SfPdfViewer.html#Syncfusion_SfPdfViewer_XForms_SfPdfViewer_DocumentSaveInitiated) event. However, in .NET MAUI, a Save button is not provided in the built-in toolbar, so the [DocumentSaveInitiated](https://help.syncfusion.com/cr/xamarin/Syncfusion.SfPdfViewer.XForms.SfPdfViewer.html#Syncfusion_SfPdfViewer_XForms_SfPdfViewer_DocumentSaveInitiated) event is not available. To save documents from the PDF viewer in .NET MAUI, you can use the [SaveDocument](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.PdfViewer.SfPdfViewer.html#Syncfusion_Maui_PdfViewer_SfPdfViewer_SaveDocument_System_IO_Stream_) method. The PdfViewer control exposes this method as an API, which can be easily integrated into your application. For more details on using the SaveDocument method, refer to the relevant UG Documentation [Save a Document](https://help.syncfusion.com/maui/pdf-viewer/save-a-document).
 
-In .NET MAUI's PdfViewer, if you need to add a Save button to the built-in toolbar, you can do so by customizing the toolbar items. Refer to the [Customize toolbar items user guide](https://help.syncfusion.com/maui/pdf-viewer/toolbar#customize-toolbar-items) for instructions on adding a custom Save button.
+In .NET MAUI PDF Viewer, you can implement custom save logic at the application level. If you would like to include a Save button in the built-in toolbar, this can be achieved by customizing the toolbar items. Refer to the [Customize toolbar items user guide](https://help.syncfusion.com/maui/pdf-viewer/toolbar#customize-toolbar-items) for instructions on adding a custom Save button.
 </td>
 </tr>
 </table>

--- a/MAUI/PDF-Viewer/Signature.md
+++ b/MAUI/PDF-Viewer/Signature.md
@@ -115,6 +115,34 @@ PdfViewer.AddAnnotation(customStamp);
 
 N> To add a text signature, you can use an image containing the signature text . You can then add it in the same manner as an image signature.
 
+## SignatureCreated event
+
+The [SignatureCreated](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.PdfViewer.SfPdfViewer.html#Syncfusion_Maui_PdfViewer_SfPdfViewer_SignatureCreated) event in the .NET MAUI PDF Viewer provides a way to access and customize the properties of a handwritten signature immediately after it is created using built-in signature dialog. This is especially helpful when you want to apply consistent styling such as stroke color, border width, or opacity to all handwritten signatures.
+
+To customize the signature, check whether the [e.Signature](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.PdfViewer.SignatureCreatedEventArgs.html#Syncfusion_Maui_PdfViewer_SignatureCreatedEventArgs_Signature) object is of type [InkAnnotation](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.PdfViewer.InkAnnotation.html), which represents a handwritten ink-based signature. If it is, you can modify its properties as needed.
+
+The following example demonstrates how to handle the SignatureCreated event and apply custom styling to a handwritten signature:
+
+{% tabs %}
+{% highlight c# %}
+// Subscribe to the SignatureCreated event to customize the appearance of handwritten signatures.
+pdfViewer.SignatureCreated += PdfViewer_SignatureCreated;
+
+// Event handler triggered when a signature is created in the PDF Viewer.
+private void PdfViewer_SignatureCreated(object? sender, SignatureCreatedEventArgs e)
+{
+    // Ensure the signature is valid and is of type InkAnnotation (used for handwritten signatures).
+    if (e.Signature is InkAnnotation handWrittenSignature)
+    {
+        // Customize the appearance of the handwritten signature.
+        handWrittenSignature.BorderWidth = 6;         // Set the thickness of the signature stroke.
+        handWrittenSignature.Color = Colors.Yellow;   // Set the stroke color to yellow.
+        handWrittenSignature.Opacity = 0.75f;         // Set the transparency level of the signature.
+    }
+}
+{% endhighlight %}
+{% endtabs %}
+
 ## Signature modal view
 
 The signature modal view appears when a signature needs to be created. The [Sfpdfviewer](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.PdfViewer.SfPdfViewer.html) notifies when the modal view is appearing and disappearing through events. The events help you in hiding and showing elements that are part of the app UI that are not necessary as long as the modal view is visible.

--- a/MAUI/PDF-Viewer/Signature.md
+++ b/MAUI/PDF-Viewer/Signature.md
@@ -115,37 +115,9 @@ PdfViewer.AddAnnotation(customStamp);
 
 N> To add a text signature, you can use an image containing the signature text . You can then add it in the same manner as an image signature.
 
-## SignatureCreated event
-
-The [SignatureCreated](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.PdfViewer.SfPdfViewer.html#Syncfusion_Maui_PdfViewer_SfPdfViewer_SignatureCreated) event in the .NET MAUI PDF Viewer provides a way to access and customize the properties of a handwritten signature immediately after it is created using built-in signature dialog. This is especially helpful when you want to apply consistent styling such as stroke color, border width, or opacity to all handwritten signatures.
-
-To customize the signature, check whether the [e.Signature](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.PdfViewer.SignatureCreatedEventArgs.html#Syncfusion_Maui_PdfViewer_SignatureCreatedEventArgs_Signature) object is of type [InkAnnotation](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.PdfViewer.InkAnnotation.html), which represents a handwritten ink-based signature. If it is, you can modify its properties as needed.
-
-The following example demonstrates how to handle the SignatureCreated event and apply custom styling to a handwritten signature:
-
-{% tabs %}
-{% highlight c# %}
-// Subscribe to the SignatureCreated event to customize the appearance of handwritten signatures.
-pdfViewer.SignatureCreated += PdfViewer_SignatureCreated;
-
-// Event handler triggered when a signature is created in the PDF Viewer.
-private void PdfViewer_SignatureCreated(object? sender, SignatureCreatedEventArgs e)
-{
-    // Ensure the signature is valid and is of type InkAnnotation (used for handwritten signatures).
-    if (e.Signature is InkAnnotation handWrittenSignature)
-    {
-        // Customize the appearance of the handwritten signature.
-        handWrittenSignature.BorderWidth = 6;         // Set the thickness of the signature stroke.
-        handWrittenSignature.Color = Colors.Yellow;   // Set the stroke color to yellow.
-        handWrittenSignature.Opacity = 0.75f;         // Set the transparency level of the signature.
-    }
-}
-{% endhighlight %}
-{% endtabs %}
-
 ## Signature modal view
 
-The signature modal view appears when a signature needs to be created. The [Sfpdfviewer](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.PdfViewer.SfPdfViewer.html) notifies when the modal view is appearing and disappearing through events. The events help you in hiding and showing elements that are part of the app UI that are not necessary as long as the modal view is visible.
+The signature modal view appears when a signature needs to be created. The [SfPdfViewer](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.PdfViewer.SfPdfViewer.html) notifies when the modal view is appearing and disappearing through events. The events help you in hiding and showing elements that are part of the app UI that are not necessary as long as the modal view is visible.
 
 **Mobile:**
 ![Signature pad modal view mobile](Images/Annotations/signature-pad-modal-view-mobile.png)
@@ -220,3 +192,30 @@ private void PdfViewer_Tapped(object sender, GestureEventArgs e)
 {% endhighlight %} 
 {% endtabs %}
 
+## Signature Created Event
+
+The [SignatureCreated](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.PdfViewer.SfPdfViewer.html#Syncfusion_Maui_PdfViewer_SfPdfViewer_SignatureCreated) event in the .NET MAUI PDF Viewer provides a way to access and customize the properties of a handwritten signature immediately after it is created using built-in signature dialog. This is especially helpful when you want to apply consistent styling such as stroke color, border width, or opacity to all handwritten signatures.
+
+To customize the signature, check whether the [e.Signature](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.PdfViewer.SignatureCreatedEventArgs.html#Syncfusion_Maui_PdfViewer_SignatureCreatedEventArgs_Signature) object is of type [InkAnnotation](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.PdfViewer.InkAnnotation.html), which represents a handwritten ink-based signature. If it is, you can modify its properties as needed.
+
+The following example demonstrates how to handle the SignatureCreated event and apply custom styling to a handwritten signature:
+
+{% tabs %}
+{% highlight c# %}
+// Subscribe to the SignatureCreated event to customize the appearance of handwritten signatures.
+pdfViewer.SignatureCreated += PdfViewer_SignatureCreated;
+
+// Event handler triggered when a signature is created in the PDF Viewer.
+private void PdfViewer_SignatureCreated(object? sender, SignatureCreatedEventArgs e)
+{
+    // Ensure the signature is valid and is of type InkAnnotation (used for handwritten signatures).
+    if (e.Signature is InkAnnotation handWrittenSignature)
+    {
+        // Customize the appearance of the handwritten signature.
+        handWrittenSignature.BorderWidth = 6;         // Set the thickness of the signature stroke.
+        handWrittenSignature.Color = Colors.Yellow;   // Set the stroke color to yellow.
+        handWrittenSignature.Opacity = 0.75f;         // Set the transparency level of the signature.
+    }
+}
+{% endhighlight %}
+{% endtabs %}


### PR DESCRIPTION
Updated the migration document for the below Xamarin APIs : 

1. AnnotationMode.HandwrittenSignature 
2. AnnotationSettings.HandwrittenSignature 
3. DocumentSaveInitiated 