### PR TITLE
970989 - Missing localization key for error messages shown in message dialog in the PDF Viewer

### DIFF
--- a/MAUI/PDF-Viewer/Localization.md
+++ b/MAUI/PDF-Viewer/Localization.md
@@ -607,4 +607,12 @@ The following table contains the default name and value details used in the SfPd
 <td>CreateSignature</td>
 <td>Create Signature</td>
 </tr>
+<tr>
+<td>XFAFormNotSupportedMessage</td>
+<td>This PDF cannot be loaded because it contains an XFA form.</td>
+</tr>
+<tr>
+<td>InvalidPasswordError</td>
+<td>Can't open an encrypted document. The password is invalid.</td>
+</tr>
 </table>


### PR DESCRIPTION
**Task link : https://dev.azure.com/EssentialStudio/Mobile%20and%20Desktop/_workitems/edit/970989
Title :  Missing localization key for error messages shown in message dialog in the PDF Viewer**

**Bug Description :** 
The PDF Viewer lacks localization keys for displaying error messages in message dialogs, leading to non-localized error outputs.
Dev PR : https://gitea.syncfusion.com/essential-studio/maui-pdfviewer/pulls/1549
Hotfix PR - https://gitea.syncfusion.com/essential-studio/maui-pdfviewer/pulls/1540

**Root cause :**
While displaying ShowMessageDialog, descriptions for exceptions were not localized. The keys for these descriptions were missing, which prevented localization.

**Fix Details :** 
Introduce new keys, such as **XFAFormNotSupportedMessage** and **InvalidPasswordError**, with default values of 'This PDF cannot be loaded because it contains an XFA form' and 'Can't open an encrypted document. The password is invalid.', respectively. In SfPdfViewer.cs, update the ShowMessageDialog method parameters to use the localized strings based on these exceptions.


**Before screenshot**
<img width="218" alt="image.png" src="attachments/a5d6e15a-d031-4a65-b658-0a7ecadb28c2">
<img width="248" alt="image.png" src="attachments/0d40ce6a-ac67-4952-af09-c1255dab3dc2">
<img width="254" alt="image.png" src="attachments/eca77ff9-e3d2-4389-8a60-ef91f4391c78">



 **After screenshot**
<img width="251" alt="image.png" src="attachments/de981066-fb05-42dd-b13d-14c6fc88a447">
<img width="241" alt="image.png" src="attachments/8b16e102-43e1-4622-b7d4-527b21e23c95">
<img width="249" alt="image.png" src="attachments/c6c057cf-ae87-4403-b1ca-43c4b8a97ab0">

 **Reason for not identifying earlier**
**Reason:**  Test Case not tested in specific device
**Action taken:** Need to add the test case in Automation
**Related areas:** NA

**Is Breaking issue?**
No

**Areas affected and ensured**
SfPdfViewer.cs
PasswordDialog.cs
SfPdfViewer.en-US.resx
SfPdfViewerResources.cs


