### PR TITLE
SfMaskedEntry (MAUI): Add IsReadOnly mode documentation to Basic-Features.md

### DIFF
--- a/MAUI/Masked-Entry/Basic-Features.md
+++ b/MAUI/Masked-Entry/Basic-Features.md
@@ -341,6 +341,32 @@ maskedEntry.SelectAllOnFocus = true;
 {% endhighlight %}
 {% endtabs %}
 
+## IsReadOnly Mode
+
+The [`IsReadOnly`]() property allows you to make the masked entry non-editable while keeping it focusable and selectable. When enabled, users can still focus and select text, but cannot modify the value via typing, cut, paste, or the keyboard. The default value of this property is `false`.
+
+{% tabs %}
+{% highlight xaml %}
+
+<editors:SfMaskedEntry WidthRequest="200"
+                       MaskType="Simple"
+                       Mask="(000) 000-0000"
+                       Value="1234567890"
+                       IsReadOnly="True" />
+
+{% endhighlight %}
+{% highlight c# %}
+
+SfMaskedEntry maskedEntry = new SfMaskedEntry();
+maskedEntry.WidthRequest = 200;
+maskedEntry.MaskType = MaskedEntryMaskType.Simple;
+maskedEntry.Mask = "(000) 000-0000";
+maskedEntry.Value = "1234567890";
+maskedEntry.IsReadOnly = true;
+
+{% endhighlight %}
+{% endtabs %}
+
 ## ReturnType
 
 The `ReturnType` property specifies the return button (e.g., Next, Done, Go) of the keyboard. It helps manage the flow between multiple input fields by defining what happens when the action button is pressed.


### PR DESCRIPTION
**Summary**
- Introduces documentation for the new IsReadOnly property in .NET MAUI SfMaskedEntry.
- Covers purpose, behavior, API link, XAML/C# examples, runtime toggle, and notes.

**What’s included**
- New section: “IsReadOnly Mode”
- API reference link to SfMaskedEntry.IsReadOnly

**Files changed**
- docs/maui/masked-entry/Basic-Features.md (added IsReadOnly section)

**API impact**
- Property: IsReadOnly (bool), default: false
- No breaking changes; read-only affects only user-initiated edits

**Screenshots**
- N/A (no image changes required). Add screenshot if desired in a follow-up.