### PR TITLE
Create content for selected dropdown item text style

### DIFF
--- a/MAUI/Autocomplete/UI-Customization.md
+++ b/MAUI/Autocomplete/UI-Customization.md
@@ -480,6 +480,38 @@ SfAutocomplete autocomplete = new SfAutocomplete()
 
 ![.NET MAUI Autocomplete Selected DropDown Item Background](Images/UICustomization/SelectedDropDownItemBackground.png)
 
+### Customize the Selected DropDown Item TextStyle
+
+The [SelectedDropDownItemTextStyle]() property in the SfAutoComplete control allows developers to customize the appearance of the selected item in the dropdown list. This feature is useful for highlighting user selections and improving the overall UI experience.
+
+{% tabs %}
+{% highlight xaml %}
+
+<editors:SfAutocomplete x:Name="autoComplete" DisplayMemberPath = "Name" TextMemberPath = "Name" ItemsSource="{Binding SocialMedias}">
+    <editors:SfAutocomplete.SelectedDropDownItemTextStyle>
+        <editors:DropDownTextStyle TextColor="Orange" FontSize="16" FontAttributes="Bold"/>
+    </editors:SfAutocomplete.SelectedDropDownItemTextStyle>
+</editors:SfAutocomplete>
+
+{% endhighlight %}
+{% highlight C# %}
+
+SfAutocomplete autoComplete = new SfAutocomplete
+{
+    ItemsSource = socialMediaViewModel.SocialMedias,
+    DisplayMemberPath = "Name",
+    TextMemberPath = "Name",
+    SelectedDropDownItemTextStyle = new DropDownTextStyle
+    {
+        TextColor = Colors.Orange,
+        FontSize = 16,
+        FontAttributes = FontAttributes.Bold
+    }
+};
+
+{% endhighlight %}
+{% endtabs %}
+
 ### Customize the DropDown Border Color
 
 The [DropDownStroke](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Inputs.DropDownControls.DropDownListBase.html#Syncfusion_Maui_Inputs_DropDownControls_DropDownListBase_DropDownStroke) property is used to modify the border color of the dropdown.

--- a/MAUI/Autocomplete/UI-Customization.md
+++ b/MAUI/Autocomplete/UI-Customization.md
@@ -480,7 +480,7 @@ SfAutocomplete autocomplete = new SfAutocomplete()
 
 ![.NET MAUI Autocomplete Selected DropDown Item Background](Images/UICustomization/SelectedDropDownItemBackground.png)
 
-### Customize the selected dropdown item's text style
+### Customize the Selected DropDown Item Text Style
 
 The [SelectedDropDownItemTextStyle]() property in the SfAutoComplete control allows developers to customize the appearance of the selected item in the dropdown list. This feature is useful for highlighting user selections and improving the overall UI experience.
 

--- a/MAUI/Autocomplete/UI-Customization.md
+++ b/MAUI/Autocomplete/UI-Customization.md
@@ -480,7 +480,7 @@ SfAutocomplete autocomplete = new SfAutocomplete()
 
 ![.NET MAUI Autocomplete Selected DropDown Item Background](Images/UICustomization/SelectedDropDownItemBackground.png)
 
-### Customize the Selected DropDown Item TextStyle
+### Customize the selected dropdown item's text style
 
 The [SelectedDropDownItemTextStyle]() property in the SfAutoComplete control allows developers to customize the appearance of the selected item in the dropdown list. This feature is useful for highlighting user selections and improving the overall UI experience.
 

--- a/MAUI/ComboBox/UI-Customization.md
+++ b/MAUI/ComboBox/UI-Customization.md
@@ -550,7 +550,7 @@ SfComboBox comboBox = new SfComboBox()
 
 ![.NET MAUI ComboBox Selected DropDown Item Background](Images/UICustomization/SelectedDropDownItemBackground.png)
 
-### Customize the Selected DropDown item text style
+### Customize the selected dropdown item's text style
 
 The [SelectedDropDownItemTextStyle]() property in the SfComboBox control allows developers to customize the appearance of the selected item in the dropdown list. This feature is useful for highlighting user selections and improving the overall UI experience.
 

--- a/MAUI/ComboBox/UI-Customization.md
+++ b/MAUI/ComboBox/UI-Customization.md
@@ -550,6 +550,44 @@ SfComboBox comboBox = new SfComboBox()
 
 ![.NET MAUI ComboBox Selected DropDown Item Background](Images/UICustomization/SelectedDropDownItemBackground.png)
 
+### Customize the Selected DropDown item text style
+
+The [SelectedDropDownItemTextStyle]() property in the SfComboBox control allows developers to customize the appearance of the selected item in the dropdown list. This feature is useful for highlighting user selections and improving the overall UI experience.
+
+{% tabs %}
+{% highlight xaml %}
+
+<editors:SfComboBox x:Name="comboBox"
+                        ItemsSource="{Binding SocialMedias}"
+                        DisplayMemberPath="Name"
+                        TextMemberPath="Name"
+                        Placeholder="Enter Media">
+    <editors:SfComboBox.SelectedDropDownItemTextStyle>
+        <editors:DropDownTextStyle TextColor="Orange" FontSize="16" FontAttributes="Bold"/>
+    </editors:SfComboBox.SelectedDropDownItemTextStyle>
+</editors:SfComboBox>
+
+{% endhighlight %}
+
+{% highlight C# %}
+
+SfComboBox comboBox = new SfComboBox() 
+{
+    ItemsSource = socialMediaViewModel.SocialMedias,
+    TextMemberPath = "Name",
+    DisplayMemberPath = "Name",
+    Placeholder="Enter Media",
+    SelectedDropDownItemTextStyle = new DropDownTextStyle
+    {
+        TextColor = Colors.Orange,
+        FontSize = 16,
+        FontAttributes = FontAttributes.Bold
+    }
+};
+
+{% endhighlight %}
+{% endtabs %}
+
 ### Customize the DropDown Border Color
 
 The [DropDownStroke](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Inputs.DropDownControls.DropDownListBase.html#Syncfusion_Maui_Inputs_DropDownControls_DropDownListBase_DropDownStroke) property is used to modify the border color of the dropdown.

--- a/MAUI/ComboBox/UI-Customization.md
+++ b/MAUI/ComboBox/UI-Customization.md
@@ -550,7 +550,7 @@ SfComboBox comboBox = new SfComboBox()
 
 ![.NET MAUI ComboBox Selected DropDown Item Background](Images/UICustomization/SelectedDropDownItemBackground.png)
 
-### Customize the selected dropdown item's text style
+### Customize the Selected DropDown Item Text Style
 
 The [SelectedDropDownItemTextStyle]() property in the SfComboBox control allows developers to customize the appearance of the selected item in the dropdown list. This feature is useful for highlighting user selections and improving the overall UI experience.
 


### PR DESCRIPTION
**Summary**
- Introduces documentation for the new SelectedDropDownItemTextStyle property in .NET MAUI SfAutoComplete.
- Covers purpose, behavior, API link, XAML/C# examples, runtime toggle, and notes.

**What’s included**
- New section: “Customize the Selected DropDown Item TextStyle”
- API reference link to SfAutocomplete.SelectedDropDownItemTextStyle

**Files changed**
- docs/maui/Autocomplete/UI-Customization.md (Customize the Selected DropDown Item TextStyle Section)

**Screenshots**
- N/A (no image changes required). Add screenshot if desired in a follow-up.