### PR TITLE
Remove UI Builder Skill link from skills list

### DIFF
--- a/maui-toc.html
+++ b/maui-toc.html
@@ -17,7 +17,6 @@
     <li>Skills
         <ul>
             <li><a href="/maui/Skills/controls-user-skills">Controls Skill</a></li>
-            <li><a href="/maui/Skills/ui-builder-skill">UI Builder Skill</a></li>
         </ul>
     </li>
 	<li>


### PR DESCRIPTION
## Description

Removed link to UI Builder Skill from the skills section as it still not released.