### PR TITLE
Fixed the legend alignment in globalization page

### DIFF
--- a/MAUI/Globalization/globalization.md
+++ b/MAUI/Globalization/globalization.md
@@ -37,10 +37,15 @@ Below is a summary of globalization capabilities supported by Syncfusion<sup>®<
 .img{
   margin:0 !important;
 }
+
+.legend{
+  display: inline-flex !important;
+  flex-direction: row !important; 
+  gap: 16px !important;
+}
 </style>
 
-<span style="display: inline-flex; flex-direction: row; gap: 16px;">
- 
+<div class="legend">
 <span style="display: inline-flex; align-items: center; gap: 6px;">
 <img src="../Images/full-support.svg" width="16"> Full Support
 </span>
@@ -56,8 +61,7 @@ Below is a summary of globalization capabilities supported by Syncfusion<sup>®<
 <span style="display: inline-flex; align-items: center; gap: 6px;">
 <img src="../Images/not-applicable.svg" width="16"> Not Applicable
 </span>
- 
-</span>
+</div>
 
 
 <style>


### PR DESCRIPTION
**Reason:**
Fixed the legend alignment in globalization page

Preview output:
<img width="826" height="243" alt="image" src="https://github.com/user-attachments/assets/8528f9a3-aa87-45b5-9c27-efaf74c7bda1" />
