### PR TITLE
API References for 2026 Volume 2 MAUI SfScheduler features and added enable or disable swipe navigation feature documentation

### DIFF
--- a/MAUI/Scheduler/agenda-view.md
+++ b/MAUI/Scheduler/agenda-view.md
@@ -374,7 +374,7 @@ this.Content = scheduler;
 {% endtabs %}
 
 ## Show or Hide Empty Days 
-The HideEmptyDays property controls the visibility of days without appointments in the AgendaView. By default, all days are displayed, including those that do not contain any appointments. Setting `HideEmptyDays` to `true` hides empty days and displays only dates that contain scheduled appointments, resulting in a more compact agenda view.
+The [HideEmptyDays](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerAgendaView.html#Syncfusion_Maui_Scheduler_SchedulerAgendaView_HideEmptyDays) property controls the visibility of days without appointments in the AgendaView. By default, all days are displayed, including those that do not contain any appointments. Setting `HideEmptyDays` to `true` hides empty days and displays only dates that contain scheduled appointments, resulting in a more compact agenda view.
 
 {% tabs %}  
 {% highlight XAML hl_lines="4" %}

--- a/MAUI/Scheduler/context-menu.md
+++ b/MAUI/Scheduler/context-menu.md
@@ -77,7 +77,7 @@ scheduler.CellContextMenu = new MenuItemCollection()
 
 ## Context Menu for Appointments
 
-The [AppointmentContextMenu](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SfScheduler.html#Syncfusion_Maui_Scheduler_SfScheduler_AppointmentContextMenu)property of the Scheduler enables users to define a set of context menu items that appear when the user performs a right tap or long press on an appointment.
+The [AppointmentContextMenu](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SfScheduler.html#Syncfusion_Maui_Scheduler_SfScheduler_AppointmentContextMenu) property of the Scheduler enables users to define a set of context menu items that appear when the user performs a right tap or long press on an appointment.
 
 {% tabs %}
 {% highlight xaml tabtitle="XAML" hl_lines="2 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27" %}

--- a/MAUI/Scheduler/context-menu.md
+++ b/MAUI/Scheduler/context-menu.md
@@ -23,15 +23,15 @@ When a context menu is configured, the Scheduler automatically displays the menu
  
 The Scheduler includes built-in commands that can be used directly in context menus.
 
-* **Add** - Creates a new appointment for the selected cell.
-* **Edit** - Opens the selected appointment for editing.
-* **Delete** - Deletes the selected appointment.
+* [Add](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerCommands.html#Syncfusion_Maui_Scheduler_SchedulerCommands_Add) - Creates a new appointment for the selected cell.
+* [Edit](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerCommands.html#Syncfusion_Maui_Scheduler_SchedulerCommands_Edit) - Opens the selected appointment for editing.
+* [Delete](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerCommands.html#Syncfusion_Maui_Scheduler_SchedulerCommands_Delete) - Deletes the selected appointment.
  
 N> Built-in `Add` and `Edit` commands work only when the [AppointmentEditorMode](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SfScheduler.html#Syncfusion_Maui_Scheduler_SfScheduler_AppointmentEditorMode) property includes the corresponding `Add` or `Edit` option.
 
 ## Context Menu for Timeslot Cells
 
-The `CellContextMenu` property of the Scheduler allows users to define a set of context menu items that appear when the user performs a right tap or long press on a timeslot cell, month cell, or the all-day panel.
+The [CellContextMenu](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SfScheduler.html#Syncfusion_Maui_Scheduler_SfScheduler_CellContextMenu) property of the Scheduler allows users to define a set of context menu items that appear when the user performs a right tap or long press on a timeslot cell, month cell, or the all-day panel.
 
 {% tabs %}
 {% highlight xaml tabtitle="XAML" hl_lines="2 4 5 6 7 8 9 10 11 12 13 14 15" %}
@@ -77,7 +77,7 @@ scheduler.CellContextMenu = new MenuItemCollection()
 
 ## Context Menu for Appointments
 
-The `AppointmentContextMenu` property of the Scheduler enables users to define a set of context menu items that appear when the user performs a right tap or long press on an appointment.
+The [AppointmentContextMenu](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SfScheduler.html#Syncfusion_Maui_Scheduler_SfScheduler_AppointmentContextMenu)property of the Scheduler enables users to define a set of context menu items that appear when the user performs a right tap or long press on an appointment.
 
 {% tabs %}
 {% highlight xaml tabtitle="XAML" hl_lines="2 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27" %}
@@ -150,11 +150,11 @@ scheduler.AppointmentContextMenu = new MenuItemCollection()
 
 ![Context-menu-for-appointments-in-maui-scheduler](images/context-menu/context-menu-for-appointments.png)
 
-N> The BindingContext of each context menu item is set to a `SchedulerContextMenuInfo` object.
+N> The BindingContext of each context menu item is set to a [SchedulerContextMenuInfo](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerContextMenuInfo.html) object.
 
 ## Customize context menu appearance
 
-You can modify the background and text appearance of the context menu displayed for scheduler cells and appointment using the `ContextMenuBackground` and `ContextMenuTextStyle` properties.
+You can modify the background and text appearance of the context menu displayed for scheduler cells and appointment using the [ContextMenuBackground](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SfScheduler.html#Syncfusion_Maui_Scheduler_SfScheduler_ContextMenuBackground) and [ContextMenuTextStyle](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SfScheduler.html#Syncfusion_Maui_Scheduler_SfScheduler_ContextMenuTextStyle) properties.
 
 {% tabs %}
 {% highlight xaml tabtitle="XAML" hl_lines="2 4 5 6 7" %}
@@ -183,14 +183,14 @@ scheduler.ContextMenuTextStyle = new SchedulerTextStyle()
 
 ## Handle Context Menu Opening
 
-The Scheduler raises the `ContextMenuOpening` event when a context menu is about to be displayed. This event provides access to the menu information and can be used to cancel the menu opening operation.
+The Scheduler raises the [ContextMenuOpening](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SfScheduler.html#Syncfusion_Maui_Scheduler_SfScheduler_ContextMenuOpening) event when a context menu is about to be displayed. This event provides access to the menu information and can be used to cancel the menu opening operation.
 
-The `SchedulerContextMenuOpeningEventArgs` class provides information about the context menu being opened.
+The [SchedulerContextMenuOpeningEventArgs](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerContextMenuOpeningEventArgs.html) class provides information about the context menu being opened.
 
-- **ContextMenu** – Gets the collection of menu items that will be displayed.
-- **MenuInfo** – Gets information about the scheduler element that invoked the context menu. Provides the following details - selected appointment, cell date and time, associated resource and scheduler instance.
-- **MenuType** – Gets the type of scheduler element (Appointment, SchedulerCell or AllDay) for which the context menu is opened.
-- **Cancel** – Specifies whether the context menu opening operation should be canceled. 
+- [ContextMenu](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerContextMenuOpeningEventArgs.html#Syncfusion_Maui_Scheduler_SchedulerContextMenuOpeningEventArgs_ContextMenu) – Gets the collection of menu items that will be displayed.
+- [MenuInfo](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerContextMenuOpeningEventArgs.html#Syncfusion_Maui_Scheduler_SchedulerContextMenuOpeningEventArgs_MenuInfo) – Gets information about the scheduler element that invoked the context menu. Provides the following details - selected appointment, cell date and time, associated resource and scheduler instance.
+- [MenuType](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerContextMenuOpeningEventArgs.html#Syncfusion_Maui_Scheduler_SchedulerContextMenuOpeningEventArgs_MenuType) – Gets the type of scheduler element (Appointment, SchedulerCell or AllDay) for which the context menu is opened.
+- 'Cancel' – Specifies whether the context menu opening operation should be canceled. 
 
 {% tabs %}
 {% highlight xaml tabtitle="XAML" hl_lines="3" %}
@@ -217,7 +217,7 @@ private void scheduler_ContextMenuOpening(object sender, SchedulerContextMenuOpe
 
 ### Cancel context menu opening
 
-The `ContextMenuOpening` event can be used to prevent a context menu from being displayed. To cancel the context menu opening operation, set the `Cancel` property of the `SchedulerContextMenuOpeningEventArgs` to `true`.
+The [ContextMenuOpening](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SfScheduler.html#Syncfusion_Maui_Scheduler_SfScheduler_ContextMenuOpening) event can be used to prevent a context menu from being displayed. To cancel the context menu opening operation, set the `Cancel` property of the [SchedulerContextMenuOpeningEventArgs](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerContextMenuOpeningEventArgs.html) to `true`.
 
 {% tabs %}
 {% highlight xaml tabtitle="XAML" hl_lines="3" %}
@@ -247,7 +247,7 @@ The clipboard functionality works as follows:
 
 ### Adding Context Menu Items
 
-The `AppointmentContextMenu` can be used to display Copy and Cut actions for appointments, while the `CellContextMenu` can be used to display the paste action for scheduler cells.
+The [AppointmentContextMenu](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SfScheduler.html#Syncfusion_Maui_Scheduler_SfScheduler_AppointmentContextMenu) can be used to display Copy and Cut actions for appointments, while the [CellContextMenu](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SfScheduler.html#Syncfusion_Maui_Scheduler_SfScheduler_CellContextMenu) can be used to display the paste action for scheduler cells.
 
 {% tabs %}
 {% highlight xaml tabtitle="XAML" %}

--- a/MAUI/Scheduler/date-navigation-restriction.md
+++ b/MAUI/Scheduler/date-navigation-restriction.md
@@ -226,6 +226,22 @@ this.Content = scheduler;
 {% endhighlight %}
 {% endtabs %}
 
+### Enable or disable swipe navigation 
+
+The `EnableSwipeNavigation` property determines whether users can navigate between dates using the scheduler's built-in navigation interactions. By default, `EnableSwipeNavigation` is set to `true`, allowing users to navigate using swipe gestures and the navigation buttons in the scheduler header. Setting `EnableSwipeNavigation` to `false` disables these navigation interactions.
+
+{% tabs %}  
+{% highlight XAML tabtitle="xaml" hl_lines="2" %}
+<scheduler:SfScheduler x:Name="scheduler" 
+                       EnableSwipeNavigation="False"/>
+{% endhighlight %}
+{% highlight C# tabtitle="c#" hl_lines="2" %}
+SfScheduler scheduler = new SfScheduler();
+scheduler.EnableSwipeNavigation = false;
+this.Content = scheduler;
+{% endhighlight %}  
+{% endtabs %}
+
 ## Date restriction
 
 In [.NET MAUI Scheduler](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SfScheduler.html), you can restrict the available dates to a range of dates using the properties [MinimumDateTime](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SfScheduler.html#Syncfusion_Maui_Scheduler_SfScheduler_MinimumDateTime), [MaximumDateTime](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SfScheduler.html#Syncfusion_Maui_Scheduler_SfScheduler_MaximumDateTime) and [SelectableDayPredicate](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SfScheduler.html#Syncfusion_Maui_Scheduler_SfScheduler_SelectableDayPredicate). It is applicable to all the Scheduler views.

--- a/MAUI/Scheduler/date-navigation-restriction.md
+++ b/MAUI/Scheduler/date-navigation-restriction.md
@@ -228,7 +228,7 @@ this.Content = scheduler;
 
 ### Enable or disable swipe navigation 
 
-The `EnableSwipeNavigation` property determines whether users can navigate between dates using the scheduler's built-in navigation interactions. By default, `EnableSwipeNavigation` is set to `true`, allowing users to navigate using swipe gestures and the navigation buttons in the scheduler header. Setting `EnableSwipeNavigation` to `false` disables these navigation interactions.
+The [EnableSwipeNavigation](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SfScheduler.html#Syncfusion_Maui_Scheduler_SfScheduler_EnableSwipeNavigation) property determines whether users can navigate between dates using the scheduler's built-in navigation interactions. By default, `EnableSwipeNavigation` is set to `true`, allowing users to navigate using swipe gestures and the navigation buttons in the scheduler header. Setting `EnableSwipeNavigation` to `false` disables these navigation interactions.
 
 {% tabs %}  
 {% highlight XAML tabtitle="xaml" hl_lines="2" %}

--- a/MAUI/Scheduler/day-week-views.md
+++ b/MAUI/Scheduler/day-week-views.md
@@ -178,7 +178,7 @@ N> [View sample in GitHub](https://github.com/SyncfusionExamples/maui-scheduler-
 
 ## Customize All-Day appointment height in Day, Week, and Work Week Views
 
-The `AllDayAppointmentHeight` property specifies the height of all-day appointments displayed in the all-day panel of the Day, Week, and WorkWeek views. Increasing this value provides additional space for appointment content and can improve readability. By default, each all-day appointment is rendered with a height of 19.
+The [AllDayAppointmentHeight](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerDaysView.html#Syncfusion_Maui_Scheduler_SchedulerDaysView_AllDayAppointmentHeight) property specifies the height of all-day appointments displayed in the all-day panel of the Day, Week, and WorkWeek views. Increasing this value provides additional space for appointment content and can improve readability. By default, each all-day appointment is rendered with a height of 19.
 
 {% tabs %}
 {% highlight XAML hl_lines="4" %}
@@ -201,7 +201,7 @@ this.Content = scheduler;
 
 ## Display spanned appointments in time slots
 
-The `AllowSpannedAppointmentsInTimeSlots` property determines whether appointments spanning more than 24 hours are displayed in the all-day panel or directly within the timeslot cells of the `Day`, `Week`, and `WorkWeek` views. By default, these appointments are rendered in the all-day panel. Setting `AllowSpannedAppointmentsInTimeSlots` to `true` displays spanned appointments within the corresponding time-slot cells.
+The [AllowSpannedAppointmentsInTimeSlots](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerDaysView.html#Syncfusion_Maui_Scheduler_SchedulerDaysView_AllowSpannedAppointmentsInTimeSlots) property determines whether appointments spanning more than 24 hours are displayed in the all-day panel or directly within the timeslot cells of the `Day`, `Week`, and `WorkWeek` views. By default, these appointments are rendered in the all-day panel. Setting `AllowSpannedAppointmentsInTimeSlots` to `true` displays spanned appointments within the corresponding time-slot cells.
 
 {% tabs %}
 {% highlight XAML hl_lines="4" %}

--- a/MAUI/Scheduler/events.md
+++ b/MAUI/Scheduler/events.md
@@ -54,21 +54,21 @@ N>
 
 ## RightTapped
 
-The `RightTapped` event occurs when a user performs a right-click action on scheduler elements in desktop platforms such as **Windows** or **macOS**. 
+The [RightTapped](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SfScheduler.html#Syncfusion_Maui_Scheduler_SfScheduler_RightTapped) event occurs when a user performs a right-click action on scheduler elements in desktop platforms such as **Windows** or **macOS**. 
 
 * `sender` - The SfScheduler object where the right-click occurred
 
-The `SchedulerRightTappedEventArgs` provides information about the right-click interaction:
+The [SchedulerRightTappedEventArgs](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerRightTappedEventArgs.html) provides information about the right-click interaction:
 
-* `Appointments` – Collection of appointments associated with the clicked element
+* [Appointments](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerInteractionEventArgs.html#Syncfusion_Maui_Scheduler_SchedulerInteractionEventArgs_Appointments) – Collection of appointments associated with the clicked element
 
-* `Date` – The date corresponding to the clicked cell or appointment
+* [Date](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerInteractionEventArgs.html#Syncfusion_Maui_Scheduler_SchedulerInteractionEventArgs_Date) – The date corresponding to the clicked cell or appointment
 
-* `Element` – The scheduler element interacted with (appointment, cell, header, resource, week number)
+* [Element](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerInteractionEventArgs.html#Syncfusion_Maui_Scheduler_SchedulerInteractionEventArgs_Element) – The scheduler element interacted with (appointment, cell, header, resource, week number)
 
-* `Resource` – The resource associated with the clicked element (in resource views)
+* [Resource](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerInteractionEventArgs.html#Syncfusion_Maui_Scheduler_SchedulerInteractionEventArgs_Resource) – The resource associated with the clicked element (in resource views)
 
-* `WeekNumber` – The week number value (Not applicable in `TimelineMonth` and `Agenda` views)
+* [WeekNumber](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerInteractionEventArgs.html#Syncfusion_Maui_Scheduler_SchedulerInteractionEventArgs_WeekNumber) – The week number value (Not applicable in `TimelineMonth` and `Agenda` views)
 
 {% tabs %}
 {% highlight xaml tabtitle="MainPage.xaml" hl_lines="2" %}
@@ -288,7 +288,7 @@ public class SchedulerInteractionViewModel
 
 ### RightTappedCommand
 
-The `RightTappedCommand` will be triggered when you perform a right tap on the scheduler view in desktop platforms (Windows and macOS) and will pass the `SchedulerRightTappedEventArgs` as the parameter.
+The [RightTappedCommand](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SfScheduler.html#Syncfusion_Maui_Scheduler_SfScheduler_RightTappedCommand) will be triggered when you perform a right tap on the scheduler view in desktop platforms (Windows and macOS) and will pass the [SchedulerRightTappedEventArgs](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerRightTappedEventArgs.html) as the parameter.
 
 {% tabs %}
 {% highlight xaml tabtitle="MainPage.xaml" hl_lines="4" %}

--- a/MAUI/Scheduler/month-view.md
+++ b/MAUI/Scheduler/month-view.md
@@ -195,7 +195,7 @@ this.Content = scheduler;
 
 ## Date text positioning in Month view
 
-The `DateHorizontalAlignment` property specifies how the date text is aligned horizontally within each cell of the scheduler’s [Month](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerMonthView.html) view. Its default value is `Center`, but you can set it to `Left`, `Right` or `Justified` to adjust the placement of the date numbers.
+The [DateHorizontalAlignment](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerMonthView.html#Syncfusion_Maui_Scheduler_SchedulerMonthView_DateHorizontalAlignment) property specifies how the date text is aligned horizontally within each cell of the scheduler’s [Month](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerMonthView.html) view. Its default value is `Center`, but you can set it to `Left`, `Right` or `Justified` to adjust the placement of the date numbers.
 
 {% tabs %}  
 {% highlight XAML tabtitle="xaml" hl_lines="4" %}
@@ -246,7 +246,7 @@ this.Content = scheduler;
 
 ## Non working days in month view
 
-The scheduler allows you to define non-working days in the Month view using the `NonWorkingDays` property. This helps highlight weekends or specific days of the week as non-working, making it easier to distinguish them from working days. By default, no days are marked as non-working. The default value of `NonWorkingDays` property is `SchedulerMonthWeekDays.None`. You can configure this property to include one or more days of the week.
+The scheduler allows you to define non-working days in the Month view using the [NonWorkingDays](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerMonthView.html#Syncfusion_Maui_Scheduler_SchedulerMonthView_NonWorkingDays) property. This helps highlight weekends or specific days of the week as non-working, making it easier to distinguish them from working days. By default, no days are marked as non-working. The default value of `NonWorkingDays` property is [SchedulerMonthWeekDays.None](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerMonthWeekDays.html#Syncfusion_Maui_Scheduler_SchedulerMonthWeekDays_None). You can configure this property to include one or more days of the week.
 
 {% tabs %}  
 {% highlight XAML tabtitle="xaml" hl_lines="4" %}
@@ -267,7 +267,7 @@ this.Content = scheduler;
 
 ### Show or Hide non working days in Month View
 
-The `HideNonWorkingDays` property is used to control the visibility of non-working days in the Month view. When `HideNonWorkingDays` is `false` (default), the specified non-working days are displayed in the MonthView. When `HideNonWorkingDays` is `true`, the specified non-working days are hidden from the MonthView.
+The [HideNonWorkingDays](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerMonthView.html#Syncfusion_Maui_Scheduler_SchedulerMonthView_HideNonWorkingDays) property is used to control the visibility of non-working days in the Month view. When `HideNonWorkingDays` is `false` (default), the specified non-working days are displayed in the MonthView. When `HideNonWorkingDays` is `true`, the specified non-working days are hidden from the MonthView.
 
 {% tabs %}  
 {% highlight XAML tabtitle="xaml" hl_lines="4" %}
@@ -291,7 +291,7 @@ this.Content = scheduler;
 
 ### Customize Non-Working Days in Month View
 
-Non-working days in the MonthView can be customized using the `NonWorkingDaysBackground` and `NonWorkingDaysTextStyle` properties of the `SchedulerMonthCellStyle`. These properties allow you to visually differentiate non-working days with custom background and text styles.
+Non-working days in the MonthView can be customized using the [NonWorkingDaysBackground](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerMonthCellStyle.html#Syncfusion_Maui_Scheduler_SchedulerMonthCellStyle_NonWorkingDaysBackground) and [NonWorkingDaysTextStyle](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerMonthCellStyle.html#Syncfusion_Maui_Scheduler_SchedulerMonthCellStyle_NonWorkingDaysTextStyle) properties of the [SchedulerMonthCellStyle](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerMonthCellStyle.html). These properties allow you to visually differentiate non-working days with custom background and text styles.
 
 {% tabs %}  
 {% highlight XAML tabtitle="xaml" hl_lines="6 7 8 9" %}
@@ -336,7 +336,7 @@ this.Content = scheduler;
 
 ## Inline Appointments in Month View
 
-Appointments can be displayed inline within the [Month](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerMonthView.html) view using the `ShowAppointmentsInline` property. When `ShowAppointmentsInline` is `false` (default), appointments are not shown inline in the MonthView. When `ShowAppointmentsInline` is `true`, tapping a date cell displays all appointments for that date inline below the tapped row. This provides a quick way to view daily schedules without switching to another view. Inline appointments are rendered in a collection view, allowing customization of styles such as background, text color, and layout.
+Appointments can be displayed inline within the [Month](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerMonthView.html) view using the [ShowAppointmentsInline](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerMonthView.html#Syncfusion_Maui_Scheduler_SchedulerMonthView_ShowAppointmentsInline) property. When `ShowAppointmentsInline` is `false` (default), appointments are not shown inline in the MonthView. When `ShowAppointmentsInline` is `true`, tapping a date cell displays all appointments for that date inline below the tapped row. This provides a quick way to view daily schedules without switching to another view. Inline appointments are rendered in a collection view, allowing customization of styles such as background, text color, and layout.
 
 {% tabs %}  
 {% highlight XAML tabtitle="xaml" hl_lines="4" %}
@@ -359,7 +359,7 @@ this.Content = scheduler;
 
 ### Appointment time format in inline view
 
-The `TimeTextFormat` property in `MonthInlineViewStyle` defines the string format used to display appointment time value in the inline view of the scheduler’s [Month](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerMonthView.html) view. By default, appointment time is shown in the "hh:mm tt" format (12‑hour clock with AM/PM). 
+The [TimeTextFormat](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.MonthInlineViewStyle.html#Syncfusion_Maui_Scheduler_MonthInlineViewStyle_TimeTextFormat) property in [MonthInlineViewStyle](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.MonthInlineViewStyle.html) defines the string format used to display appointment time value in the inline view of the scheduler’s [Month](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerMonthView.html) view. By default, appointment time is shown in the "hh:mm tt" format (12‑hour clock with AM/PM). 
 
 {% tabs %}  
 {% highlight XAML tabtitle="XAML" hl_lines="6" %}
@@ -389,7 +389,7 @@ scheduler.MonthView.MonthInlineViewStyle = new MonthInlineViewStyle()
 
 ### Appointment height in inline view
 
-The `ItemHeight` property in `MonthInlineViewStyle` specifies the vertical height of each appointment item displayed in the inline view of the scheduler’s [Month](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerMonthView.html) view. By default, each appointment item has a height of 50 units. You can increase or decrease this value to adjust how compact or spacious the inline appointment list appears.
+The [ItemHeight](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.MonthInlineViewStyle.html#Syncfusion_Maui_Scheduler_MonthInlineViewStyle_ItemHeight) property in [MonthInlineViewStyle](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.MonthInlineViewStyle.html) specifies the vertical height of each appointment item displayed in the inline view of the scheduler’s [Month](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerMonthView.html) view. By default, each appointment item has a height of 50 units. You can increase or decrease this value to adjust how compact or spacious the inline appointment list appears.
 
 {% tabs %}  
 {% highlight XAML tabtitle="XAML" hl_lines="6" %}
@@ -421,7 +421,7 @@ scheduler.MonthView.MonthInlineViewStyle = new MonthInlineViewStyle()
 
 #### Customize inline appointments appearance using TextStyle
 
-The `MonthInlineViewStyle` property allows you to customize the appearance of inline view in the scheduler’s [Month](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerMonthView.html) view using the `Background` and `TextStyle` properties.
+The [MonthInlineViewStyle](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerMonthView.html#Syncfusion_Maui_Scheduler_SchedulerMonthView_MonthInlineViewStyle) property allows you to customize the appearance of inline view in the scheduler’s [Month](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerMonthView.html) view using the [Background](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.MonthInlineViewStyle.html#Syncfusion_Maui_Scheduler_MonthInlineViewStyle_Background) and [TextStyle](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.MonthInlineViewStyle.html#Syncfusion_Maui_Scheduler_MonthInlineViewStyle_TextStyle) properties.
 
 {% tabs %}  
 {% highlight XAML tabtitle="XAML" hl_lines="6 7 8 9 10" %}
@@ -462,7 +462,7 @@ scheduler.MonthView.MonthInlineViewStyle = new MonthInlineViewStyle()
 
 #### Customize inline appointments appearance using DateTemplate
 
-The `MonthInlineViewItemTemplate` property allows you to define a custom DataTemplate to customize the appearance of appointment items displayed in the inline view of the scheduler’s [Month](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerMonthView.html) view.
+The [MonthInlineViewItemTemplate](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerMonthView.html#Syncfusion_Maui_Scheduler_SchedulerMonthView_MonthInlineViewItemTemplate) property allows you to define a custom DataTemplate to customize the appearance of appointment items displayed in the inline view of the scheduler’s [Month](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerMonthView.html) view.
 
 {% tabs %}  
 {% highlight XAML hl_lines="5 21" %}
@@ -498,15 +498,15 @@ The `MonthInlineViewItemTemplate` property allows you to define a custom DataTem
 
 ### MonthInlineAppointmentTapped
 
-The `MonthInlineAppointmentTapped` event is raised when a user taps on an appointment displayed in the inline view of the scheduler’s [Month](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerMonthView.html) view.
+The [MonthInlineAppointmentTapped](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SfScheduler.html#Syncfusion_Maui_Scheduler_SfScheduler_MonthInlineAppointmentTapped) event is raised when a user taps on an appointment displayed in the inline view of the scheduler’s [Month](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerMonthView.html) view.
 
 * `sender` - Refers to the SfScheduler instance that raised the event.
 
-This event provides details about the tapped appointment and the selected date through the `MonthInlineAppointmentTappedEventArgs`.
+This event provides details about the tapped appointment and the selected date through the [MonthInlineAppointmentTappedEventArgs](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.MonthInlineAppointmentTappedEventArgs.html).
 
-* `Appointment`: Gets the tapped appointment. Returns null if the user taps an empty area.
+* [Appointment](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.MonthInlineAppointmentTappedEventArgs.html#Syncfusion_Maui_Scheduler_MonthInlineAppointmentTappedEventArgs_Appointment): Gets the tapped appointment. Returns null if the user taps an empty area.
 
-* `SelectedDate`: Gets the date of the month cell where the inline view was opened.
+* [SelectedDate](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.MonthInlineAppointmentTappedEventArgs.html#Syncfusion_Maui_Scheduler_MonthInlineAppointmentTappedEventArgs_SelectedDate): Gets the date of the month cell where the inline view was opened.
 
 {% tabs %}
 {% highlight xaml tabtitle="MainPage.xaml" hl_lines="3" %}

--- a/MAUI/Scheduler/timeline-views.md
+++ b/MAUI/Scheduler/timeline-views.md
@@ -514,7 +514,7 @@ N>
 
 ### Display special time regions in TimelineMonth
 
-The `ShowMonthTimeRegions` property defines whether special time regions are displayed in the scheduler’s [TimelineMonth](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerViews.html#Syncfusion_Maui_Scheduler_SchedulerViews_TimelineMonth) view.
+The [ShowMonthTimeRegions](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerTimelineView.html#Syncfusion_Maui_Scheduler_SchedulerTimelineView_ShowMonthTimeRegions) property defines whether special time regions are displayed in the scheduler’s [TimelineMonth](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerViews.html#Syncfusion_Maui_Scheduler_SchedulerViews_TimelineMonth) view.
 
 By default, the property is set to `false`, so time regions are hidden. Setting it to `true` makes the scheduler show the configured [SchedulerTimeRegion](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.Scheduler.SchedulerTimeSlotView.html#Syncfusion_Maui_Scheduler_SchedulerTimeSlotView_TimeRegions) values within the `TimelineMonth` view.
 


### PR DESCRIPTION
Added API reference links for the MAUI SfScheduler features introduced in the 2026 Volume 2 release. Also included the missing documentation for enabling and disabling swipe navigation.