### PR TITLE
Addressed CI failure in Navigation Drawer UG Documentation

### DIFF
--- a/MAUI/NavigationDrawer/Multi-Drawer.md
+++ b/MAUI/NavigationDrawer/Multi-Drawer.md
@@ -108,7 +108,7 @@ Call the [ToggleSecondaryDrawer](https://help.syncfusion.com/cr/maui/Syncfusion.
 
 {% tabs %}
 
-{% highlight x#aml %}
+{% highlight xaml %}
 
 <Grid>
     <navigationDrawer:SfNavigationDrawer x:Name="navigationDrawer">


### PR DESCRIPTION
### Description

* We have addressed CI failure in Navigation Drawer UG Documentation. The xaml tag mentioned wrongly in the documentation. We have corrected it.