### PR TITLE
Redundant keyword errors are cleared for MAUI AssistView, ParallaxView, PullToRefresh and TreeView controls.

### DIFF
--- a/MAUI/AIAssistView/data-binding.md
+++ b/MAUI/AIAssistView/data-binding.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Data binding in .NET MAUI AI AssistView Control | Syncfusion®
-description: Learn here about binding the Request and Response Items in Syncfusion® .NET MAUI AssistView control.
+description: Learn here about binding the Request and Response Items in Syncfusion® .NET MAUI AI AssistView control.
 platform: MAUI
 control: SfAIAssistView
 documentation: ug

--- a/MAUI/Parallax-View/Getting-started.md
+++ b/MAUI/Parallax-View/Getting-started.md
@@ -32,7 +32,7 @@ Before proceeding, ensure the following are set up:
 2. Name the project and choose a location. Then, click **Next**.
 3. Select the .NET framework version and click **Create**.
 
-## Step 2: Install the Syncfusion<sup>®</sup> MAUI ParallaxView NuGet package
+## Step 2: Install the Syncfusion<sup>®</sup> MAUI Parallax View NuGet package
 
 1. In **Solution Explorer**, right-click the project and choose **Manage NuGet Packages**.
 2. Search for [Syncfusion.Maui.ParallaxView](https://www.nuget.org/packages/Syncfusion.Maui.ParallaxView/) and install the latest version.
@@ -56,11 +56,11 @@ Before proceeding, ensure the following are set up:
 3. Select the project location, type the project name and press Enter.
 4. Then choose **Create project**
 
-## Step 2: Install the Syncfusion<sup>®</sup> MAUI ParallaxView NuGet package
+## Step 2: Install the Syncfusion<sup>®</sup> MAUI Parallax View NuGet package
 
 1. Press <kbd>Ctrl</kbd> + <kbd>`</kbd> (backtick) to open the integrated terminal in Visual Studio Code.
 2. Ensure you're in the project root directory where your .csproj file is located.
-3. Run the command `dotnet add package Syncfusion.Maui.ParallaxView` to install the Syncfusion<sup>®</sup> .NET MAUI ParallaxView package.
+3. Run the command `dotnet add package Syncfusion.Maui.ParallaxView` to install the Syncfusion<sup>®</sup> .NET MAUI Parallax View package.
 4. To ensure all dependencies are installed, run `dotnet restore`.
 
 {% endtabcontent %}
@@ -80,7 +80,7 @@ Before proceeding, ensure the following are set up:
 2. Enter the Project Name, Solution Name, and Location.
 3. Select the .NET framework version and click Create.
 
-## Step 2: Install the Syncfusion<sup>®</sup> MAUI ParallaxView NuGet package
+## Step 2: Install the Syncfusion<sup>®</sup> MAUI Parallax View NuGet package
 
 1. In **Solution Explorer,** right-click the project and choose **Manage NuGet Packages.**
 2. Search for [Syncfusion.Maui.ParallaxView](https://www.nuget.org/packages/Syncfusion.Maui.ParallaxView/) and install the latest version.

--- a/MAUI/Pull-to-Refresh/customization.md
+++ b/MAUI/Pull-to-Refresh/customization.md
@@ -9,7 +9,7 @@ documentation: ug
 
 # Customization in .NET MAUI Pull to Refresh
 
-The .NET MAUI PullToRefresh control supports customization of various features, including TransitionMode, PullingThreshold, ProgressBackground, ProgressColor, and more. The control can be personalized using the following properties.
+The .NET MAUI Pull to Refresh control supports customization of various features, including TransitionMode, PullingThreshold, ProgressBackground, ProgressColor, and more. The control can be personalized using the following properties.
 
 ## PullableContent
 
@@ -25,9 +25,9 @@ The [PullableContent](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.PullTo
                             RefreshViewWidth="30">
     <syncfusion:SfPullToRefresh.PullableContent>
             <Label x:Name="Monthlabel" 
+                    VerticalTextAlignment="Start" />
                     TextColor="White" 
                     HorizontalTextAlignment="Center"   
-                    VerticalTextAlignment="Start" />
     </syncfusion:SfPullToRefresh.PullableContent>
 </syncfusion:SfPullToRefresh>
 
@@ -57,9 +57,9 @@ pullToRefresh.TransitionMode = PullToRefreshTransitionType.SlideOnTop;
 {% endhighlight %}
 {% endtabs %}
 
-![Syncfusion .NET MAUI PullToRefresh with slide on top transition mode.](Images/customization/net-maui-pulltorefresh-getting-started.png)
+![Syncfusion .NET MAUI Pull to Refresh with slide on top transition mode.](Images/customization/net-maui-pulltorefresh-getting-started.png)
 
-The following code example shows how to set the `TransitionMode` as `Push` to PullToRefresh. This transition moves the refresh content and main content simultaneously.
+The following code example shows how to set the `TransitionMode` as `Push` to Pull to Refresh. This transition moves the refresh content and main content simultaneously.
 
 {% tabs %}
 {% highlight xaml tabtitle="MainPage.xaml" hl_lines="2" %}
@@ -75,11 +75,11 @@ pullToRefresh.TransitionMode = PullToRefreshTransitionType.Push;
 {% endhighlight %}
 {% endtabs %}
 
-![Syncfusion .NET MAUI PullToRefresh with push transition mode.](Images/customization/net-maui-pulltorefresh-getting-started-push.png)
+![Syncfusion .NET MAUI Pull to Refresh with push transition mode.](Images/customization/net-maui-pulltorefresh-getting-started-push.png)
 
 ## RefreshViewThreshold
 
-The threshold value for the refresh view, indicating the starting position of the progress indicator within the view.This is a `double` value; the default is `50`.
+The threshold value for the refresh view, indicating the starting position of the progress indicator within the view. This is a `double` value; the default is `50`.
 
 {% tabs %}
 {% highlight xaml tabtitle="MainPage.xaml" hl_lines="2" %}
@@ -265,11 +265,11 @@ pullToRefresh.EndRefreshing();
 
 ## Host .NET MAUI DataGrid as pullable content
 
-The `PullToRefresh` control provides support for loading any custom control as pullable content. To host the .NET MAUI `DataGrid` inside the `PullToRefresh`, follow these steps.
+The `Pull to Refresh` control provides support for loading any custom control as pullable content. To host the .NET MAUI `DataGrid` inside the `Pull to Refresh`, follow these steps.
 <ol>
     <li> Add the required assembly references as discussed in the <a href="https://help.syncfusion.com/maui/datagrid/getting-started">DataGrid</a> and PullToRefresh.</li>
     <li> Define the `OrdersInfo` collection in a ViewModel and implement a `Refresh Item source(int count)` method that updates it. See the <a href="https://github.com/SyncfusionExamples/load-datagrid-as-pullable-content-of-.net-maui-pull-to-refresh">View sample in GitHub</a> for a complete example.</li>
-    <li> Import PullToRefresh and DataGrid control namespace as follows.</li>
+    <li> Import Pull to Refresh and DataGrid control namespace as follows.</li>
     <br/>
 {% tabs %}
 {% highlight xaml tabtitle="MainPage.xaml" %}
@@ -286,9 +286,9 @@ using Syncfusion.Maui.PullToRefresh;
 {% endhighlight %}
 {% endtabs %}
     <br/>
-    <li> Define the DataGrid as PullableContent of the PullToRefresh.</li> 
+    <li> Define the DataGrid as PullableContent of the Pull to Refresh.</li> 
     <li> Handle the pull to refresh events for refreshing the data. </li>
-    <li> Customize the required properties of the DataGrid and PullToRefresh based on your requirement.</li>
+    <li> Customize the required properties of the DataGrid and Pull to Refresh based on your requirement.</li>
 </ol>
 
 This is how the final output will look like when hosting a Datagrid control as pullable content.
@@ -379,9 +379,9 @@ N> [View sample in GitHub](https://github.com/SyncfusionExamples/load-datagrid-a
 
 ## Host .NET MAUI ListView as pullable content
 
-To host the .NET MAUI `ListView` inside the `PullToRefresh` to update items in the list while performing the pull to refresh action, follow these steps.
+To host the .NET MAUI `ListView` inside the `Pull to Refresh` to update items in the list while performing the pull to refresh action, follow these steps.
 <ol>
-    <li>	Add the required assembly references as discussed in the <a href="https://help.syncfusion.com/maui/listview/getting-started">ListView</a> and PullToRefresh.</li>
+    <li>	Add the required assembly references as discussed in the <a href="https://help.syncfusion.com/maui/listview/getting-started">ListView</a> and Pull to Refresh.</li>
     <li>	Define the `InboxInfos` collection in a `ListViewInboxInfoViewModel` and implement an `AddItemsRefresh(int count)` method that adds new items. See the <a href="https://github.com/SyncfusionExamples/load-listview-as-pullable-content-of-.net-maui-pull-to-refresh">View sample in GitHub</a> for a complete example.</li>
     <li>	Import the SfPullToRefresh control and SfListView control namespace as follows.</li>
     <br/>
@@ -492,11 +492,11 @@ N> [View sample in GitHub](https://github.com/SyncfusionExamples/load-listview-a
 
 If you run the above sample with the [TransitionMode](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.PullToRefresh.SfPullToRefresh.html#Syncfusion_Maui_PullToRefresh_SfPullToRefresh_TransitionMode) as Push, the output will look as follows.
 
-![Syncfusion .NET MAUI PullToRefresh with ListView hosted with push transition mode.](Images/customization/net-maui-listview-push.gif)
+![Syncfusion .NET MAUI Pull to Refresh with ListView hosted with push transition mode.](Images/customization/net-maui-listview-push.gif)
 
 ## Pulling and refreshing template
 
-The `PullToRefresh` allows you to set a template for the pulling and refreshing view. The pulling and refreshing templates can be set using the [SfPullToRefresh.PullingViewTemplate](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.PullToRefresh.SfPullToRefresh.html#Syncfusion_Maui_PullToRefresh_SfPullToRefresh_PullingViewTemplate) and [SfPullToRefresh.RefreshingViewTemplate](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.PullToRefresh.SfPullToRefresh.html#Syncfusion_Maui_PullToRefresh_SfPullToRefresh_RefreshingViewTemplate) properties, respectively. Both templates accept a `DataTemplate` and can be assigned independently if you need different views for each state. During the pulling gesture, the `Pulling` event provides a [PullingEventArgs](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.PullToRefresh.PullingEventArgs.html) `Progress` value whose sign indicates the direction; use `Math.Abs(e.Progress)` for an absolute value.
+The `Pull to Refresh` allows you to set a template for the pulling and refreshing view. The pulling and refreshing templates can be set using the [SfPullToRefresh.PullingViewTemplate](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.PullToRefresh.SfPullToRefresh.html#Syncfusion_Maui_PullToRefresh_SfPullToRefresh_PullingViewTemplate) and [SfPullToRefresh.RefreshingViewTemplate](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.PullToRefresh.SfPullToRefresh.html#Syncfusion_Maui_PullToRefresh_SfPullToRefresh_RefreshingViewTemplate) properties, respectively. Both templates accept a `DataTemplate` and can be assigned independently if you need different views for each state. During the pulling gesture, the `Pulling` event provides a [PullingEventArgs](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.PullToRefresh.PullingEventArgs.html) `Progress` value whose sign indicates the direction; use `Math.Abs(e.Progress)` for an absolute value.
 
 Refer to the following code example in which a [SfCircularProgressBar](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.ProgressBar.SfCircularProgressBar.html?tabs=tabid-1) is loaded in the pulling view template and refreshing view template.
 
@@ -644,4 +644,4 @@ public class PullToRefreshTemplateBehavior : Behavior<ContentPage>
 {% endhighlight %}
 {% endtabs %}
 
-![Syncfusion .NET MAUI PullToRefresh view Template.](Images/customization/net-maui-template-slideontop.gif)
+![Syncfusion .NET MAUI Pull to Refresh view Template.](Images/customization/net-maui-template-slideontop.gif)

--- a/MAUI/Pull-to-Refresh/getting-started.md
+++ b/MAUI/Pull-to-Refresh/getting-started.md
@@ -28,7 +28,7 @@ Before proceeding, ensure the following are set up:
 2. Name the project and choose a location, then click **Next**.
 3. Select the .NET framework version and click **Create**.
 
-## Step 2: Install the Syncfusion<sup>®</sup> MAUI PullToRefresh NuGet package
+## Step 2: Install the Syncfusion<sup>®</sup> MAUI Pull to Refresh NuGet package
 
 1. In **Solution Explorer**, right-click the project and choose **Manage NuGet Packages**.
 2. Search for [Syncfusion.Maui.PullToRefresh](https://www.nuget.org/packages/Syncfusion.Maui.PullToRefresh/) and install the latest version.
@@ -52,11 +52,11 @@ Before proceeding, ensure the following are set up:
 3. Select the project location, type the project name, and press <kbd>Enter</kbd>.
 4. Then choose **Create project**.
 
-## Step 2: Install the Syncfusion<sup>®</sup> MAUI PullToRefresh NuGet package
+## Step 2: Install the Syncfusion<sup>®</sup> MAUI Pull to Refresh NuGet package
 
 1. Press <kbd>Ctrl</kbd>+<kbd>`</kbd> (backtick) to open the integrated terminal in Visual Studio Code.
 2. Ensure you are in the project root directory where your `.csproj` file is located.
-3. Run the command `dotnet add package Syncfusion.Maui.PullToRefresh` to install the Syncfusion<sup>®</sup> .NET MAUI PullToRefresh package.
+3. Run the command `dotnet add package Syncfusion.Maui.PullToRefresh` to install the Syncfusion<sup>®</sup> .NET MAUI Pull to Refresh package.
 4. To ensure all dependencies are installed, run `dotnet restore`.
 {% endtabcontent %}
 {% tabcontent JetBrains Rider %}
@@ -75,7 +75,7 @@ Before proceeding, ensure the following are set up:
 2. Enter the project name, solution name, and location.
 3. Select the .NET framework version and click **Create**.
 
-## Step 2: Install the Syncfusion<sup>®</sup> MAUI PullToRefresh NuGet package
+## Step 2: Install the Syncfusion<sup>®</sup> MAUI Pull to Refresh NuGet package
 
 1. In **Solution Explorer**, right-click the project and choose **Manage NuGet Packages**.
 2. Search for [Syncfusion.Maui.PullToRefresh](https://www.nuget.org/packages/Syncfusion.Maui.PullToRefresh/) and install the latest version.
@@ -164,7 +164,7 @@ For MVVM scenarios, you can also bind `IsRefreshing` to a boolean property on yo
 
 The following image shows the default `SlideOnTop` transition behavior:
 
-![.NET MAUI PullToRefresh with default slide on top transition mode](Images/getting-started/maui-pull-to-refresh-slideontop-mode.gif)
+![.NET MAUI Pull to Refresh with default slide on top transition mode](Images/getting-started/maui-pull-to-refresh-slideontop-mode.gif)
 
 You can download the PullToRefresh Getting Started sample from [GitHub](https://github.com/SyncfusionExamples/getting-started-with-.net-maui-pull-to-refresh/tree/master).
 
@@ -186,7 +186,7 @@ To use the [Push](https://help.syncfusion.com/cr/maui/Syncfusion.Maui.PullToRefr
 {% endhighlight %}
 {% endtabs %}
 
-![.NET MAUI PullToRefresh with push transition mode](Images/getting-started/maui-pull-to-refresh-push-mode.gif)
+![.NET MAUI Pull to Refresh with push transition mode](Images/getting-started/maui-pull-to-refresh-push-mode.gif)
 
 For details on additional properties such as `ProgressColor`, `PullingThreshold`, and `RefreshContent`, see the [Customization](customization.md) page.
 

--- a/MAUI/Pull-to-Refresh/overview.md
+++ b/MAUI/Pull-to-Refresh/overview.md
@@ -9,7 +9,7 @@ documentation: ug
 
 # Overview of .NET MAUI Pull to Refresh
 
-Syncfusion® [.NET MAUI PullToRefresh](https://www.syncfusion.com/maui-controls/maui-pull-to-refresh) is a refresh control that enables users to interact with and refresh content using a pull gesture. The control displays a progress indicator as the user pulls the content. Once the configured pull threshold is reached and the gesture is released, the refresh action is triggered.
+Syncfusion® [.NET MAUI Pull to Refresh](https://www.syncfusion.com/maui-controls/maui-pull-to-refresh) is a refresh control that enables users to interact with and refresh content using a pull gesture. The control displays a progress indicator as the user pulls the content. Once the configured pull threshold is reached and the gesture is released, the refresh action is triggered.
 
 The refresh distance required to trigger an update is configurable through the `PullingThreshold` property. This allows you to adjust the pull experience based on your application's needs.
 

--- a/MAUI/TreeView/overview.md
+++ b/MAUI/TreeView/overview.md
@@ -11,7 +11,7 @@ documentation: ug
 
 The Syncfusion<sup>&reg;</sup> [.NET MAUI TreeView](https://www.syncfusion.com/maui-controls/maui-treeview) is a data-oriented control that displays the hierarchical data,such as organizational structures and nested connections, within your application. It provides a user-friendly way to interact with complex data structures and navigate through different levels of information by allowing users to expand and collapse nodes to reveal or hide underlying information.
 
-![Syncfusion .NET MAUI tree view overview](Images/overview/treeview_overview.png)
+![Syncfusion .NET MAUI TreeView overview](Images/overview/treeview_overview.png)
  
 ## Business use cases
 


### PR DESCRIPTION
Redundant keyword errors are cleared for below MAUI controls.
- AssistView
- ParallaxView,
- PullToRefresh
- TreeView.