### PR TITLE
Update .NET MAUI UI Kit documentation for Visual Studio and VS code integration

### DIFF
--- a/MAUI/visual-studio-code-integration/Essential-UI-Kit.md
+++ b/MAUI/visual-studio-code-integration/Essential-UI-Kit.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Essential® UI Kit for .NET MAUI | MAUI | Syncfusion®
-description: The Syncfusion® Essential® UI Kit for .NET MAUI extension provides the predefined design Screens for the MAUI Apps.
+title: Essential® UI Kit for .NET MAUI Visual Studio Code | Syncfusion®
+description: The Syncfusion® Essential® UI Kit for .NET MAUI Visual Studio Code extension provides predefined design screens and templates for .NET MAUI applications.
 platform: maui
 control: Syncfusion<sup>®</sup> Extensions
 documentation: ug
 ---
 
-# Essential<sup>®</sup> UI Kit for .NET MAUI
+# Essential® UI Kit for .NET MAUI Visual Studio Code
 
 The Essential<sup>®</sup> UI Kit for .NET MAUI provides pre-built XAML templates, making it easy to create user interfaces for cross-platform applications. It follows a well-structured separation of View, ViewModel, and Model classes, simplifying the integration of business logic and the modification of existing views.
 

--- a/MAUI/visual-studio-integration/Essential-UI-Kit.md
+++ b/MAUI/visual-studio-integration/Essential-UI-Kit.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Essential® UI Kit for .NET MAUI | MAUI | Syncfusion®
-description: The Syncfusion® Essential® UI Kit for .NET MAUI extension provides the predefined design Screens for the MAUI Apps.
+title: Essential® UI Kit for .NET MAUI Visual Studio | Syncfusion®
+description: The Syncfusion® Essential® UI Kit for .NET MAUI Visual Studio extension provides predefined design screens and templates for .NET MAUI applications.
 platform: maui
 control: Syncfusion<sup>®</sup> Extensions
 documentation: ug
 ---
 
-# Essential<sup>®</sup> UI Kit for .NET MAUI
+# Essential® UI Kit for .NET MAUI Visual Studio
 
 Essential<sup>®</sup> UI Kit for .NET MAUI comes with ready-to-use XAML templates, enabling you to effortlessly design user interfaces for cross-platform applications. It follows a clear separation of the View, ViewModel, and Model classes, making it easy to integrate your business logic and modify existing views.
 


### PR DESCRIPTION
**Description**
Rename the .NET MAUI UI Kit documentation to reflect Visual Studio Code extension branding and update the description to clarify that the extension provides predefined screens and templates for .NET MAUI applications.