### PR TITLE
Updated the Valid Image Path in Linear gauge UG

### DIFF
--- a/MAUI/Linear-Gauge/ticks.md
+++ b/MAUI/Linear-Gauge/ticks.md
@@ -150,7 +150,7 @@ SfLinearGauge gauge = new SfLinearGauge();
 
 {% endtabs %}
 
-![Set .NET MAUI Linear Gauge tick position](images/axis-ticks/label-placement.PNG)
+![Set .NET MAUI Linear Gauge tick position](images/axis-labels/label-placement.PNG)
 
 
 ## Customize Tick Offset


### PR DESCRIPTION
This branch is created to update the [Customize Label Position](https://help.syncfusion.com/maui/linear-gauge/ticks#customize-tick-position) in MAUI Linear gauge control UG page.

Reference:
<img width="1098" height="552" alt="image" src="https://github.com/user-attachments/assets/bf2e363b-85af-44d1-b6d2-69b6dc57ba1a" />
