### PR TITLE
MAUI - Adding common feature in release notes

### DIFF
--- a/MAUI/Release-notes/v34.2.2.md
+++ b/MAUI/Release-notes/v34.2.2.md
@@ -52,7 +52,7 @@ Syncfusion collects only a limited set of anonymous usage data during developmen
 The following information may be collected:
 
 - **Component Name** : The Syncfusion component being used (for example, Chart, DataGrid or ListView). Used to understand component usage and adoption.
-- **Assembly Name** : The Syncfusion assembly or package in use (for example, Syncfusion.MAUI.DataGrid). Used for product diagnostics.
+- **Assembly Name** : The Syncfusion assembly or package in use (for example, Syncfusion.Maui.DataGrid). Used for product diagnostics.
 - **SDK Name** : The Syncfusion SDK being used (for example, Chart SDK). Used to understand SDK adoption.
 - **SDK Version** : The SDK version shipped with the product. Used for release planning and compatibility analysis.
 - **Framework** : The target development framework (for example, .NET). Used to understand framework adoption.

--- a/MAUI/Release-notes/v34.2.2.md
+++ b/MAUI/Release-notes/v34.2.2.md
@@ -7,6 +7,95 @@ documentation: ug
 
 # Essential Studio® for MAUI - v34.2.2 Release Notes
 
+## Common
+
+### Feature
+
+#### Telemetry
+
+Starting with this release (v34.2.2), Syncfusion® .NET MAUI components support development-only telemetry. The collected telemetry helps us better understand component usage, feature adoption, and technology trends, allowing us to prioritize future enhancements and product investments.
+
+Telemetry is enabled by default in development environments and collects only anonymous usage information. It is automatically disabled in production environments, and no telemetry is collected from deployed applications or end users.
+
+#### Telemetry-supported Components:
+
+Telemetry is supported across major Syncfusion® .NET MAUI components, including data visualization, data management, scheduling, editing, file management, and diagramming controls. For a complete list of supported components are listed below.
+
+| Component | Assembly |
+|-----------|----------|
+| AIAssistView | Syncfusion.Maui.AIAssistView |
+| Charts | Syncfusion.Maui.Charts |
+| ComboBox | Syncfusion.Maui.Inputs |
+| DataGrid | Syncfusion.Maui.DataGrid |
+| ImageEditor | Syncfusion.Maui.ImageEditor |
+| Kanban | Syncfusion.Maui.Kanban |
+| ListView | Syncfusion.Maui.ListView |
+| PDFViewer | Syncfusion.Maui.PdfViewer |
+| RichTextEditor | Syncfusion.Maui.RichTextEditor |
+| Scheduler | Syncfusion.Maui.Scheduler |
+| SmartDataGrid | Syncfusion.Maui.SmartDataGrid |
+| SmartScheduler | Syncfusion.Maui.SmartScheduler |
+
+#### Why we collect telemetry:
+
+The collected telemetry helps us:
+
+- Understand feature adoption and usage trends.
+- Identify frequently used components and frameworks.
+- Prioritize future product investments and roadmap decisions.
+- Detect compatibility trends across .NET versions, operating systems, and development environments.
+
+#### What information is collected?
+
+Syncfusion collects only a limited set of anonymous usage data during development to understand product usage and improve product planning. No personal information or user-generated content is collected.
+
+The following information may be collected:
+
+- **Component Name** : The Syncfusion component being used (for example, Chart, DataGrid or ListView). Used to understand component usage and adoption.
+- **Assembly Name** : The Syncfusion assembly or package in use (for example, Syncfusion.MAUI.DataGrid). Used for product diagnostics.
+- **SDK Name** : The Syncfusion SDK being used (for example, Chart SDK). Used to understand SDK adoption.
+- **SDK Version** : The SDK version shipped with the product. Used for release planning and compatibility analysis.
+- **Framework** : The target development framework (for example, .NET). Used to understand framework adoption.
+- **Framework Version** : The version of the target framework (for example, .NET 8). Helps prioritize framework support.
+- **Operating System** : The operating system used during development (for example, Windows, Linux, or macOS). Used for platform compatibility analysis.
+- **Machine Architecture** : Processor architecture (for example, x64, x86, or ARM64). Used to understand hardware trends.
+- **Session ID (Hashed)** : A randomly generated identifier representing a single development session. Used to group telemetry events within the same session.
+- **Event Name** : Product events (for example, component_initialized or feature_name). Used to understand component and feature usage trends.
+
+N> No user-generated content (e.g., code, files, or personal data) is collected.
+
+#### What information is Not collected?
+
+Syncfusion does not collect:
+
+- Personal information (name, email address, customer ID, company information)
+- Source code
+- Documents or files
+- Application data
+- User-generated content
+- Business data
+- Prompts or AI conversations
+- Authentication credentials
+- License keys
+- Any information that can directly identify an individual
+
+#### How to disable telemetry (Opt-out)
+
+Telemetry can be disabled at any time by calling `Telemetry.Disable()`during the application startup process, before using any Syncfusion features in your .NET MAUI application.
+
+{% highlight %}
+
+using Syncfusion.Telemetry; 
+
+// Disable Syncfusion telemetry.  
+Telemetry.Disable();  
+// Your Syncfusion code follows here.
+{% endhighlight %}
+
+Once disabled, Syncfusion application continue to function normally. The only difference is that telemetry data will no longer be collected.
+
+N> Call `Telemetry.Disable()` before creating or using any Syncfusion features in your application.
+
 {% include release-info.html date="August 05, 2026"  version="v34.2.2" passed="53413" failed="0" %} 
 
 {% directory path: _includes/release-notes/v34.2.2 %}

--- a/MAUI/Release-notes/v34.2.2.md
+++ b/MAUI/Release-notes/v34.2.2.md
@@ -137,7 +137,7 @@ N> Call `Telemetry.Disable()` before creating or using any Syncfusion features i
 | Funnel Charts | 14 | 14 | 0 | All Passed |
 | Image Editor | 1688 | 1688 | 0 | All Passed |
 | Kanban Board | 1060 | 1060 | 0 | All Passed |
-| Lineaar Gauge | 668 | 668 | 0 | All Passed |
+| Linear Gauge | 668 | 668 | 0 | All Passed |
 | ListView | 5161 | 5161 | 0 | All Passed |
 | Maps | 1835 | 1835 | 0 | All Passed |
 | Markdown Viewer | 116 | 116 | 0 | All Passed |


### PR DESCRIPTION
## Description

Added Telemetry documentation under the Common section of the .NET MAUI v34.2.2 release notes.

## Changes Made

- Added Telemetry feature details in the Common section.
- Included an overview of development-only telemetry support.
- Added the list of telemetry-supported .NET MAUI components and assemblies.
- Documented the purpose of telemetry collection.
- Added details about the information collected and excluded from telemetry.
- Added telemetry opt-out instructions using `Telemetry.Disable()`.
- Included a .NET MAUI code snippet demonstrating how to disable telemetry during application startup.